### PR TITLE
Add Claude Code guardrails, style guide, and skills

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,9 @@
 {
+  "env": {
+    "CLAUDE_CODE_MAX_OUTPUT_TOKENS": "64000"
+  },
   "enabledPlugins": {
-    "frontend-design@claude-plugins-official": true
+    "frontend-design@claude-plugins-official": true,
+    "skill-creator@claude-plugins-official": true
   }
 }

--- a/.claude/skills/create-feature/SKILL.md
+++ b/.claude/skills/create-feature/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: create-feature
+description: Implement a GitHub feature issue. Use when the user says "create feature #N", "implement feature #N", "build feature #N", or similar.
+argument-hint: [issue-number]
+---
+
+## Context
+
+!`gh issue view $ARGUMENTS --json title,body,comments,labels,assignees 2>/dev/null || echo "ERROR: Could not fetch issue $ARGUMENTS. Check the issue number and try again."`
+
+---
+
+## Workflow
+
+Implement GitHub feature **#$ARGUMENTS** by following these steps strictly in order.
+
+### 1. Understand the issue
+
+Read the issue context above carefully. Identify the feature requirements, acceptance criteria, and any constraints.
+
+If the issue context shows an error, stop and tell the user the issue could not be loaded.
+
+### 2. Create a branch
+
+```bash
+git checkout -b create-feature-$ARGUMENTS
+```
+
+If the branch already exists, switch to it with `git checkout create-feature-$ARGUMENTS`.
+
+### 3. Plan the feature
+
+Before writing any code:
+
+- **Ask clarifying questions** — resolve ambiguity about scope, edge cases, and requirements.
+- **Suggest improvements** — propose UX enhancements, performance wins, better defaults, or anything that makes the feature more useful. Get approval before including them.
+- **Save the plan** once scope is agreed:
+
+```
+docs/plans/features/<feature-name>-<NNNN>.md
+```
+
+where `<NNNN>` is the issue number zero-padded to 4 digits.
+
+### 4. Locate the code
+
+Search `src/` for the relevant components, types, and files. Read the code thoroughly before making changes.
+
+### 5. Implement the feature
+
+- Follow the code style and architectural conventions in CLAUDE.md.
+- Write tests for any new pure functions.
+
+### 6. Verify
+
+Run:
+
+```bash
+npm test && npm run build
+```
+
+Both must pass with zero errors. If tests fail:
+- Determine whether the failure is related to your change or pre-existing.
+- Fix any failures caused by your change before proceeding.
+- Do **not** skip or delete failing tests.
+
+### 7. Stage and commit
+
+```bash
+git add .
+```
+
+Write a concise commit message in the format: `feat: <what was added> (#$ARGUMENTS)`
+
+### 8. Push and open a PR
+
+```bash
+git push -u origin create-feature-$ARGUMENTS
+```
+
+Then create a PR:
+
+```bash
+gh pr create \
+  --title "Feature: <Issue Title>" \
+  --body "Closes #$ARGUMENTS.
+
+## What changed
+<bullet points describing the feature>
+
+## How it was verified
+- All tests pass
+- Build succeeds
+<any additional verification>" \
+  --base main
+```
+
+Return the PR URL when done.

--- a/.claude/skills/fix-bug/SKILL.md
+++ b/.claude/skills/fix-bug/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: fix-bug
+description: Fix a GitHub issue. Use when the user says "fix bug #N", "fix issue #N", or similar.
+argument-hint: [issue-number]
+---
+
+## Context
+
+!`gh issue view $ARGUMENTS --json title,body,comments,labels,assignees 2>/dev/null || echo "ERROR: Could not fetch issue $ARGUMENTS. Check the issue number and try again."`
+
+---
+
+## Workflow
+
+Fix GitHub issue **#$ARGUMENTS** by following these steps strictly in order.
+
+### 1. Understand the issue
+
+Read the issue context above carefully. Identify:
+- The expected behaviour vs actual behaviour
+- Any reproduction steps or error messages
+- Which files or components are likely involved
+
+If the issue context shows an error, stop and tell the user the issue could not be loaded.
+
+### 2. Create a branch
+
+```bash
+git checkout -b fix-bug-$ARGUMENTS
+```
+
+If the branch already exists, switch to it with `git checkout fix-bug-$ARGUMENTS`.
+
+### 3. Locate the code
+
+Search `src/` for the relevant components, types, and files mentioned in or implied by the issue. Read the code thoroughly before making changes.
+
+### 4. Implement the fix
+
+- Make the **minimal change** required to fix the issue.
+- Follow the code style and architectural conventions in CLAUDE.md.
+- Write or update tests for any modified pure functions.
+
+### 5. Verify
+
+Run:
+
+```bash
+npm test && npm run build
+```
+
+Both must pass with zero errors. If tests fail:
+- Determine whether the failure is related to your change or pre-existing.
+- Fix any failures caused by your change before proceeding.
+- Do **not** skip or delete failing tests.
+
+### 6. Stage and commit
+
+```bash
+git add .
+```
+
+Write a concise commit message in the format: `fix: <what was fixed> (#$ARGUMENTS)`
+
+### 7. Push and open a PR
+
+```bash
+git push -u origin fix-bug-$ARGUMENTS
+```
+
+Then create a PR:
+
+```bash
+gh pr create \
+  --title "Fix: <Issue Title>" \
+  --body "Closes #$ARGUMENTS.
+
+## What changed
+<1-3 bullet points describing the fix>
+
+## How it was verified
+- All tests pass
+- Build succeeds
+<any additional verification>" \
+  --base main
+```
+
+Return the PR URL when done.

--- a/.claude/skills/teach-lesson/SKILL.md
+++ b/.claude/skills/teach-lesson/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: teach-lesson
+description: Extract a key insight from a completed task and write a short teaching lesson. Use after finishing a non-trivial bug fix, feature, refactor, or investigation.
+---
+
+## Workflow
+
+After completing non-trivial work (bug fix, feature, refactor, or investigation), extract one key insight — something you had to know or figure out — and teach it as a short, digestible lesson.
+
+### 1. Decide whether a lesson is warranted
+
+Write a lesson when the conversation involved:
+- A non-obvious TypeScript, React, or Vite pattern you had to apply
+- A math or algorithmic concept central to the fix
+- A tricky architectural decision or tradeoff
+- A subtle bug whose root cause is worth understanding
+- A domain-specific insight about WGI scoring, percussion data, or CompetitionSuite parsing
+
+**Skip it** for purely mechanical changes (typo fixes, renaming, trivial config tweaks).
+
+### 2. Write the lesson
+
+Keep it short — aim for under 30 lines. Use this structure:
+
+```markdown
+# <Lesson Title>
+
+**Why it matters:** One sentence on when this knowledge applies.
+
+## The concept
+
+Two to four sentences explaining the core idea clearly.
+
+## In this codebase
+
+A concrete code snippet or reference to the specific file/function where this appeared.
+
+## Key takeaway
+
+One crisp sentence the reader should remember.
+```
+
+### 3. Save the lesson
+
+Get the current short commit hash:
+
+```bash
+git rev-parse --short HEAD
+```
+
+Save to:
+
+```
+docs/lessons/<lesson-category>/<lesson-topic>/<lesson-name>-<short-hash>.md
+```
+
+- **`lesson-category`** — high-level grouping (e.g. `typescript`, `react`, `scoring`, `parsing`, `architecture`)
+- **`lesson-topic`** — more specific subject within the category (e.g. `generics`, `hooks`, `wgi-eras`, `competitionsuite`)
+- **`lesson-name`** — kebab-case name for the specific lesson (e.g. `cross-era-domain-normalization`)
+- **`short-hash`** — first 7 characters of the current git commit hash
+
+Reuse existing category and topic directories where they fit. Create new ones only when no existing grouping applies.
+
+### 4. Surface the takeaway
+
+After writing the lesson, briefly surface the key takeaway inline in the conversation so it is visible without opening the file.

--- a/.claude/statusline-command.sh
+++ b/.claude/statusline-command.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# Claude Code status line — rich info panel
+# Reads JSON from stdin, outputs a single formatted line.
+# Segments: model | directory | git branch | context % bar | token count | elapsed time
+
+input=$(cat)
+
+# ── Parse JSON fields ──────────────────────────────────────────────────────
+model=$(echo "$input" | jq -r '.model.display_name // "Claude"')
+cwd=$(echo "$input" | jq -r '.workspace.current_dir // .cwd // "?"')
+transcript=$(echo "$input" | jq -r '.transcript_path // ""')
+
+used_pct=$(echo "$input"   | jq -r '.context_window.used_percentage      // ""')
+
+total_in=$(echo "$input"  | jq -r '.context_window.total_input_tokens  // 0')
+total_out=$(echo "$input" | jq -r '.context_window.total_output_tokens // 0')
+
+# ── ANSI color helpers ────────────────────────────────────────────────────
+RESET='\033[0m'
+DIM='\033[2m'
+
+C_CYAN='\033[36m'
+C_BLUE='\033[34m'
+C_GREEN='\033[32m'
+C_YELLOW='\033[33m'
+C_RED='\033[31m'
+C_MAGENTA='\033[35m'
+C_GRAY='\033[90m'
+
+SEP="${C_GRAY}│${RESET}"
+
+# ── Model ─────────────────────────────────────────────────────────────────
+model_str="${C_MAGENTA}${model}${RESET}"
+
+# ── Current directory (shorten home prefix, keep last 3 components) ───────
+home_dir="${HOME:-/home/node}"
+short_cwd="${cwd/#$home_dir/\~}"
+component_count=$(echo "$short_cwd" | tr -cd '/' | wc -c)
+if [ "$component_count" -gt 3 ]; then
+  short_cwd="...$(echo "$short_cwd" | rev | cut -d'/' -f1-3 | rev)"
+fi
+dir_str="${C_BLUE}${short_cwd}${RESET}"
+
+# ── Git branch — cached in /tmp for 5s to avoid repeated subprocess calls ─
+cache_key=$(echo "$cwd" | tr '/' '_')
+cache_file="/tmp/claude_gitbranch_${cache_key}"
+cache_ttl=5
+
+git_str=""
+if [ -d "${cwd}/.git" ] || git --no-optional-locks -C "$cwd" rev-parse --git-dir &>/dev/null 2>&1; then
+  if [ -f "$cache_file" ] && [ $(( $(date +%s) - $(stat -c %Y "$cache_file" 2>/dev/null || echo 0) )) -lt $cache_ttl ]; then
+    branch=$(cat "$cache_file")
+  else
+    branch=$(git --no-optional-locks -C "$cwd" symbolic-ref --short HEAD 2>/dev/null \
+             || git --no-optional-locks -C "$cwd" rev-parse --short HEAD 2>/dev/null \
+             || echo "")
+    echo "$branch" > "$cache_file"
+  fi
+  if [ -n "$branch" ]; then
+    git_str="${C_CYAN}${branch}${RESET}"
+  fi
+fi
+
+# ── Context window bar (8-cell block bar with color gradient) ─────────────
+ctx_str=""
+if [ -n "$used_pct" ]; then
+  pct_int=${used_pct%.*}
+  pct_int=${pct_int:-0}
+
+  bar_width=8
+  filled=$(( pct_int * bar_width / 100 ))
+  empty=$(( bar_width - filled ))
+  bar=""
+  for i in $(seq 1 $filled);  do bar="${bar}█"; done
+  for i in $(seq 1 $empty);   do bar="${bar}░"; done
+
+  # Green < 50%, yellow < 80%, red >= 80%
+  if   [ "$pct_int" -lt 50 ]; then bar_color="${C_GREEN}"
+  elif [ "$pct_int" -lt 80 ]; then bar_color="${C_YELLOW}"
+  else                              bar_color="${C_RED}"
+  fi
+
+  ctx_str="${bar_color}${bar}${RESET} ${DIM}${pct_int}%${RESET}"
+fi
+
+# ── Token count (compact K/M format) ──────────────────────────────────────
+token_str=""
+if [ "$total_in" -gt 0 ] || [ "$total_out" -gt 0 ]; then
+  total=$(( total_in + total_out ))
+  if [ "$total" -ge 1000000 ]; then
+    token_label=$(awk -v t="$total" 'BEGIN { printf "%.1fM", t / 1000000 }')
+  elif [ "$total" -ge 1000 ]; then
+    token_label=$(awk -v t="$total" 'BEGIN { printf "%.1fK", t / 1000 }')
+  else
+    token_label="${total}"
+  fi
+  token_str="${C_YELLOW}${token_label} tok${RESET}"
+fi
+
+# ── Session elapsed time (from transcript directory mtime) ────────────────
+time_str=""
+if [ -n "$transcript" ] && [ -f "$transcript" ]; then
+  session_dir=$(dirname "$transcript")
+  start_ts=$(stat -c %Y "$session_dir" 2>/dev/null || echo "")
+  if [ -n "$start_ts" ]; then
+    now_ts=$(date +%s)
+    elapsed=$(( now_ts - start_ts ))
+    hrs=$(( elapsed / 3600 ))
+    mins=$(( (elapsed % 3600) / 60 ))
+    secs=$(( elapsed % 60 ))
+    if [ "$hrs" -gt 0 ]; then
+      time_str="${DIM}${hrs}h${mins}m${RESET}"
+    else
+      time_str="${DIM}${mins}m${secs}s${RESET}"
+    fi
+  fi
+fi
+
+# ── Assemble status line ─────────────────────────────────────────────────
+parts=()
+parts+=("${model_str}")
+parts+=("${dir_str}")
+[ -n "$git_str"  ] && parts+=("${git_str}")
+[ -n "$ctx_str"  ] && parts+=("${ctx_str}")
+[ -n "$token_str" ] && parts+=("${token_str}")
+[ -n "$time_str" ] && parts+=("${time_str}")
+
+line=""
+for part in "${parts[@]}"; do
+  if [ -z "$line" ]; then
+    line="${part}"
+  else
+    line="${line}  ${SEP}  ${part}"
+  fi
+done
+
+printf "%b\n" "${line}"

--- a/.claude/typescript-style-guide.md
+++ b/.claude/typescript-style-guide.md
@@ -1,0 +1,585 @@
+# TypeScript Style Guide
+
+> Source: <https://mkosir.github.io/typescript-style-guide/>
+
+## Introduction
+
+The TypeScript Style Guide provides conventions and best practices for consistent, maintainable code through a combination of automated tooling and design principles.
+
+### Purpose
+- Enforce consistency using ESLint, TypeScript, Prettier, and similar tools
+- Reduce code review discussions about style
+- Maintain code quality as projects grow in complexity
+- Accelerate development cycles through standardization
+
+### Disclaimer
+This guide is opinionated. Teams should adapt conventions to their specific needs while maintaining internal consistency.
+
+### Requirements
+- TypeScript v5+
+- typescript-eslint v8 with strict-type-checked configuration
+- Assumes (but not limited to): React, Playwright, Vitest
+
+---
+
+## TLDR — Key Principles
+
+- Embrace const assertions for type safety and immutability
+- Strive for data immutability using `Readonly` and `ReadonlyArray`
+- Make majority of object properties required; use optional properties sparingly
+- Embrace discriminated unions
+- Avoid type assertions in favor of proper type definitions
+- Pursue pure, stateless functions with single responsibility
+- Maintain consistent and readable naming conventions
+- Use named exports exclusively
+- Organize code by feature with collocation
+
+---
+
+## Types
+
+### Type Inference
+
+**Explicitly declare types only when narrowing them.**
+
+```typescript
+// ❌ Avoid
+const employees = new Map(); // Inferred as 'Map<any, any>'
+const [userRole, setUserRole] = useState('admin'); // Inferred as 'string'
+
+// ✅ Use
+const employees = new Map<string, number>();
+const [userRole, setUserRole] = useState<UserRole>('admin');
+```
+
+Avoid explicit types when they can be inferred:
+
+```typescript
+// ❌ Avoid
+const userRole: string = 'admin';
+const [isActive, setIsActive] = useState<boolean>(false);
+
+// ✅ Use
+const USER_ROLE = 'admin'; // Narrowed to literal type 'admin'
+const [isActive, setIsActive] = useState(false);
+```
+
+### Data Immutability
+
+Use `Readonly` and `ReadonlyArray` to prevent accidental mutations:
+
+```typescript
+// ❌ Avoid
+const removeFirstUser = (users: Array<User>) => {
+  return users.splice(1);
+};
+
+// ✅ Use
+const removeFirstUser = (users: ReadonlyArray<User>) => {
+  return users.slice(1);
+};
+```
+
+### Required & Optional Object Properties
+
+**Strive to make majority of object properties required.**
+
+```typescript
+// ❌ Avoid
+type User = {
+  id?: number;
+  email?: string;
+  dashboardAccess?: boolean;
+};
+
+// ✅ Use discriminated unions
+type AdminUser = {
+  role: 'admin';
+  id: number;
+  email: string;
+  dashboardAccess: boolean;
+};
+
+type RegularUser = {
+  role: 'regular';
+  id: number;
+  email: string;
+};
+
+type User = AdminUser | RegularUser;
+```
+
+### Discriminated Union
+
+Discriminated unions (tagged unions) provide powerful type safety benefits:
+
+- Remove optional properties through variant separation
+- Enable exhaustiveness checking in switches
+- Avoid boolean flag complexity
+- Clarify code intent
+- Support TypeScript type narrowing
+- Simplify refactoring
+
+```typescript
+type Circle = { kind: 'circle'; radius: number };
+type Square = { kind: 'square'; size: number };
+type Shape = Circle | Square;
+
+const calculateArea = (shape: Shape) => {
+  switch (shape.kind) {
+    case 'circle':
+      return Math.PI * shape.radius ** 2;
+    case 'square':
+      return shape.size * shape.size;
+  }
+};
+```
+
+### Type-Safe Constants With Satisfies
+
+Combine `as const` for immutability with `satisfies` for validation:
+
+```typescript
+// ✅ Array constants
+type UserRole = 'admin' | 'editor' | 'moderator' | 'viewer' | 'guest';
+const DASHBOARD_ACCESS_ROLES = ['admin', 'editor', 'moderator'] as const
+  satisfies ReadonlyArray<UserRole>;
+
+// ✅ Object constants
+type OrderStatus = {
+  pending: 'pending' | 'idle';
+  fulfilled: boolean;
+  error: string;
+};
+const IDLE_ORDER = {
+  pending: 'idle',
+  fulfilled: true,
+  error: 'Shipping Error',
+} as const satisfies OrderStatus;
+```
+
+### Template Literal Types
+
+Use template literal types to create precise, type-safe string constructs:
+
+```typescript
+// String Patterns
+type Version = `v${number}.${number}.${number}`;
+const appVersion: Version = 'v2.6.1';
+
+// API Endpoints
+type ApiRoute = 'users' | 'posts' | 'comments';
+type ApiEndpoint = `/api/${ApiRoute}`;
+const userEndpoint: ApiEndpoint = '/api/users';
+
+// CSS Utilities
+type BaseColor = 'blue' | 'red' | 'yellow';
+type Variant = 50 | 100 | 200 | 300 | 400;
+type Color = `${BaseColor}-${Variant}` | `#${string}`;
+const iconColor: Color = 'blue-400';
+```
+
+### Type `any` & `unknown`
+
+**Never use `any`.** Use `unknown` as the type-safe alternative:
+
+```typescript
+// ❌ Avoid
+const foo: any = 'five';
+const bar: number = foo; // No type error
+
+// ✅ Use
+const foo: unknown = 5;
+// Narrow the type before use
+const isNumber = (num: unknown): num is number => typeof num === 'number';
+if (!isNumber(foo)) throw Error('Expected number');
+const bar: number = foo;
+```
+
+### Type & Non-nullability Assertions
+
+Avoid type assertions (`user as User`) and non-nullability assertions (`user!.name`) except in rare cases. When unavoidable, use `@ts-expect-error` with a clear description — never `@ts-ignore`.
+
+### Type Definition
+
+**Use `type` for all type definitions consistently.** Exception: `interface` for declaration merging only.
+
+```typescript
+// ❌ Avoid (interface for regular shapes)
+interface UserInfo {
+  name: string;
+}
+
+// ✅ Use
+type UserRole = 'admin' | 'guest';
+type UserInfo = {
+  name: string;
+  role: UserRole;
+};
+```
+
+### Array Types
+
+Use generic array syntax:
+
+```typescript
+// ❌ Avoid
+const x: string[] = ['foo', 'bar'];
+const y: readonly string[] = ['foo', 'bar'];
+
+// ✅ Use
+const x: Array<string> = ['foo', 'bar'];
+const y: ReadonlyArray<string> = ['foo', 'bar'];
+```
+
+### Type Imports and Exports
+
+Always separate type imports from runtime imports:
+
+```typescript
+// ❌ Avoid
+import { MyClass } from 'some-library';
+
+// ✅ Use
+import type { MyClass } from 'some-library';
+```
+
+---
+
+## Functions
+
+### General Principles
+
+Functions should:
+- Have single responsibility
+- Be stateless (same inputs produce same outputs)
+- Accept at least one argument and return data
+- Be pure without side effects
+
+### Single Object Arg
+
+Use a single object parameter instead of multiple arguments (exception: single primitive args):
+
+```typescript
+// ❌ Avoid
+transformUserInput('client', false, 60, 120, null, true, 2000);
+
+// ✅ Use
+transformUserInput({
+  method: 'client',
+  isValidated: false,
+  minLines: 60,
+  maxLines: 120,
+  defaultInput: null,
+  shouldLog: true,
+  timeout: 2000,
+});
+```
+
+### Args as Discriminated Type
+
+Use discriminated unions to eliminate optional function parameters:
+
+```typescript
+// ❌ Avoid
+type StatusParams = {
+  data?: Products;
+  title?: string;
+  time?: number;
+  error?: string;
+};
+
+// ✅ Use
+type StatusSuccessParams = { status: 'success'; data: Products; title: string };
+type StatusLoadingParams = { status: 'loading'; time: number };
+type StatusErrorParams  = { status: 'error'; error: string };
+type StatusParams = StatusSuccessParams | StatusLoadingParams | StatusErrorParams;
+```
+
+### Return Types
+
+Explicitly declare return types for public APIs and wherever it improves clarity:
+
+```typescript
+function getUserById(id: string): User | null { /* ... */ }
+const formatDate = (date: Date): string => date.toISOString();
+```
+
+---
+
+## Variables
+
+### Const Assertion
+
+Use `as const` for constants to narrow types and ensure immutability:
+
+```typescript
+// Objects
+const FOO_LOCATION = { x: 50, y: 130 } as const;
+// Type { readonly x: 50; readonly y: 130; }
+
+// Arrays
+const BAR_LOCATION = [50, 130] as const; // Type readonly [50, 130]
+
+// Template literals
+const RATE_LIMIT_MESSAGE = `Max requests/min is ${25}.` as const;
+```
+
+### Enums & Const Assertion
+
+**Avoid enums.** Prefer literal types or const assertion:
+
+```typescript
+// ❌ Avoid
+enum UserRole { GUEST = 'guest', MODERATOR = 'moderator' }
+
+// ✅ Use literal types
+type UserRole = 'guest' | 'moderator' | 'administrator';
+
+// ✅ Use const assertion for iteration
+const USER_ROLES = ['guest', 'moderator', 'administrator'] as const;
+type UserRole = (typeof USER_ROLES)[number];
+
+// ✅ Use const assertion objects
+const COLORS = { primary: '#B33930', secondary: '#113A5C' } as const;
+type ColorValue = (typeof COLORS)[keyof typeof COLORS];
+```
+
+### Type Union & Boolean Flags
+
+Embrace type unions instead of multiple boolean flags:
+
+```typescript
+// ❌ Avoid
+const isPending, isProcessing, isConfirmed, isExpired;
+
+// ✅ Use
+type UserStatus = 'pending' | 'processing' | 'confirmed' | 'expired';
+const userStatus: UserStatus;
+```
+
+### Null & Undefined
+
+- Use `null` to explicitly indicate no value
+- Use `undefined` when a value doesn't exist
+
+---
+
+## Naming
+
+### Named Exports
+
+**Always use named exports.** Avoid default exports.
+
+```typescript
+// ❌ Avoid
+export default function MyComponent() {}
+
+// ✅ Use
+export function MyComponent() {}
+export const myHelper = () => {};
+```
+
+### Naming Conventions
+
+| Category | Convention | Example |
+|---|---|---|
+| Local variables | camelCase | `products`, `productsFiltered` |
+| Booleans | `is`/`has` prefix | `isDisabled`, `hasProduct` |
+| Constants | UPPER_SNAKE_CASE | `FEATURED_PRODUCT_ID` |
+| Functions | camelCase | `filterProductsByType()` |
+| Types | PascalCase | `OrderStatus`, `ProductItem` |
+| Generics | PascalCase prefixed with `T` | `<TRequest>`, `<TFooBar>` |
+| React components | PascalCase | `ProductItem`, `ProductsPage` |
+| Prop types | Component name + `Props` | `ProductItemProps` |
+| React hooks | `use` prefix | `useGetProducts()` |
+
+### File Naming
+
+- Use **kebab-case** for all file names: `paddle-viz.ts`, `user-profile.tsx`.
+- Match the file name to its primary export or purpose: a file exporting `PaddleCard` lives in `paddle-card.tsx`.
+- Avoid generic names like `utils.ts`, `helpers.ts`, or `types.ts` — name the file after what it actually contains (`math.ts`, `paddle-viz.ts`).
+- Group related files by colocation rather than by type: keep `foo.ts` and `foo.test.ts` together rather than separating source and tests into different directories.
+
+### Callback Props
+
+- Props: `on*` prefix
+- Handlers: `handle*` prefix
+
+```typescript
+// ❌ Avoid
+<Button click={actionClick} />
+
+// ✅ Use
+<Button onClick={handleClick} />
+```
+
+### Custom Hooks Return Value
+
+Custom hooks should return objects, not arrays:
+
+```typescript
+// ❌ Avoid
+const [products, errors] = useGetProducts();
+
+// ✅ Use
+const { products, errors } = useGetProducts();
+```
+
+### Abbreviations & Acronyms
+
+Treat as whole words (only first letter capitalised):
+
+```typescript
+// ❌ Avoid
+const FAQList = [];
+const generateUserURL = () => {};
+
+// ✅ Use
+const FaqList = [];
+const generateUserUrl = () => {};
+```
+
+### Comments
+
+Favour expressive code over comments. Comments should explain "why," not "what."
+
+```typescript
+// ❌ Avoid
+// convert to minutes
+const m = s * 60;
+
+// ✅ Use expressive names
+const SECONDS_IN_MINUTE = 60;
+const minutes = seconds * SECONDS_IN_MINUTE;
+
+// ✅ Explain rationale
+// TODO: Move filtering to backend once API v2 releases
+const filteredUsers = frontendFiltering(selectedUsers);
+```
+
+---
+
+## Source Organisation
+
+### Code Collocation
+
+- Organise files/folders by feature
+- Collocate related code as close as possible
+
+### Imports
+
+- **Relative imports:** For files within the same feature
+- **Absolute imports:** For all other cases
+
+```typescript
+// ❌ Avoid
+import { bar } from '../../../../../../distant-folder';
+
+// ✅ Use absolute for distant code
+import { locationApi } from '@api/locationApi';
+
+// ✅ Use relative within feature
+import { baz } from './baz';
+```
+
+---
+
+## React
+
+### Required & Optional Props
+
+**Make majority of props required.**
+
+```typescript
+// ❌ Avoid
+type ButtonProps = { label?: string; onClick?: () => void };
+
+// ✅ Use
+type ButtonProps = { label: string; onClick: () => void };
+```
+
+### Props as Discriminated Type
+
+```typescript
+type StatusSuccess = { status: 'success'; data: Products; title: string };
+type StatusLoading = { status: 'loading'; time: number };
+type StatusError   = { status: 'error'; error: string };
+type StatusProps   = StatusSuccess | StatusLoading | StatusError;
+
+export const Status = (props: StatusProps) => {
+  switch (props.status) {
+    case 'success': return <div>{props.title}</div>;
+    case 'loading': return <div>Loading {props.time}ms</div>;
+    case 'error':   return <div>Error: {props.error}</div>;
+  }
+};
+```
+
+### Props To State
+
+When initialising state from a prop, prefix the prop with `initial`:
+
+```typescript
+// ❌ Avoid
+export const Foo = ({ productName }: { productName: string }) => {
+  const [productName, setProductName] = useState(productName);
+};
+
+// ✅ Use
+export const Foo = ({ initialProductName }: { initialProductName: string }) => {
+  const [productName, setProductName] = useState(initialProductName);
+};
+```
+
+### Props Type
+
+Avoid `React.FC`. Annotate props with an inline type and let the return type be inferred:
+
+```typescript
+// ❌ Avoid
+export const Foo: React.FC<FooProps> = ({ name }) => {};
+
+// ✅ Use
+type FooProps = { name: string };
+export const Foo = ({ name }: FooProps) => {};
+```
+
+### Store & Pass Data
+
+- Pass only necessary props; do not forward entire objects
+- Consider props, URL state, or composition before reaching for global state
+- Use React compound components for related components
+
+---
+
+## Tests
+
+### What & How To Test
+
+**Do:**
+- Write short, explicit, intentional tests
+- Follow AAA pattern (Arrange, Act, Assert)
+- Write tests reflecting user behaviour and business logic
+- Keep tests independent and isolated
+
+**Don't:**
+- Test implementation details
+- Re-test library/framework functionality
+- Test just for coverage metrics
+
+### Test Description
+
+Follow: `it('should ... when ...')`
+
+```typescript
+// ❌ Avoid
+it('accepts ISO date format where date is parsed');
+
+// ✅ Use
+it('should return parsed date as YYYY-MM when input is ISO format');
+```
+
+### Snapshot Tests
+
+Discourage snapshot testing. Exception: design system components with critical, stable output.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,173 @@
+# CLAUDE.md — drumline-scores
+
+Agent instructions for Claude Code working in this repository.
+
+For the full design document (personas, scoring model, data architecture, parsing spec) see **[`docs/designs/DESIGN.md`](docs/designs/DESIGN.md)**.
+
+---
+
+## Branch Protection
+
+The `main` branch is protected — **all changes must go through a pull request**. Direct pushes to `main` are rejected.
+
+- Always create a feature branch, push it, and open a PR.
+- Do not attempt to `git push` to `main` directly.
+
+---
+
+## Development Commands
+
+```bash
+npm run dev            # Start Vite dev server (hot reload)
+npm run build          # tsc type-check + Vite production build
+npm run preview        # Serve the dist/ build locally
+npm test               # Run Vitest unit tests
+```
+
+**Always run `npm test && npm run build` after code changes** to confirm all tests pass and the build compiles.
+
+---
+
+## Code Style
+
+All TypeScript and React code must follow the conventions in **[`.claude/typescript-style-guide.md`](.claude/typescript-style-guide.md)** (sourced from <https://mkosir.github.io/typescript-style-guide/>). The subsections below specify how those rules apply to this codebase and add project-specific guidance.
+
+### TypeScript
+
+The project uses `strict: true` plus additional strictness flags. **All code must be strictly typed — no `any`, no type assertions, no `@ts-ignore`.**
+
+Key tsconfig flags in effect:
+
+```jsonc
+"strict": true,
+"noUnusedLocals": true,
+"noUnusedParameters": true,
+"noFallthroughCasesInSwitch": true,
+"verbatimModuleSyntax": true,   // use `import type` for type-only imports
+"erasableSyntaxOnly": true,      // no enums, no namespaces (use const objects / union types)
+"noUncheckedSideEffectImports": true
+```
+
+- **`type` over `interface`** — use `type` for all type definitions; never `interface`.
+- **`Array<T>` over `T[]`** — use generic array syntax throughout.
+- **`import type`** — required for all type-only imports (enforced by `verbatimModuleSyntax`).
+- **No `any`** — use `unknown` + narrowing instead.
+- **No type assertions** — fix the type; do not use `as` or `!` to silence errors.
+- **No enums** — use union string literals or `as const` objects (enforced by `erasableSyntaxOnly`).
+- **No `namespace`** — the codebase uses plain ES modules.
+- **`as const`** — use for object/array constants to narrow types and ensure immutability.
+
+### React
+
+- Target **React 19** patterns. Use the React compiler mental model: keep components pure, avoid manual memoisation unless profiling proves it necessary.
+- Use `StrictMode` — do not remove it.
+- Prefer function components with hooks. No class components.
+- Do not use `React.FC` — annotate props with an inline `type` and let the return type be inferred.
+- Event handlers: prefer inline arrow functions for simple cases; extract named handlers only when the handler is non-trivial or referenced more than once.
+- Event props use `on*` prefix; handler functions use `handle*` prefix.
+- `useEffect` for external effects only (DOM mutations, subscriptions). Do not use `useEffect` for derived state — compute it inline or with `useMemo`.
+- Keep sub-components in the same file unless a component grows large enough to justify extraction.
+
+### Naming
+
+| Category | Convention | Example |
+|---|---|---|
+| Local variables | camelCase | `ensembles`, `filteredScores` |
+| Booleans | `is`/`has` prefix | `isMarching`, `hasCaption` |
+| Constants | UPPER_SNAKE_CASE | `MARCHING_ERAS`, `CAP_COLORS` |
+| Functions | camelCase | `getProgression()`, `calcCaptionScore()` |
+| Types | PascalCase | `EnsembleScore`, `CaptionDef` |
+| React components | PascalCase | `ScoreCard`, `ProgressionChart` |
+| Prop types | Component name + `Props` | `ScoreCardProps` |
+| React hooks | `use` prefix | `useFavoriteEnsemble()` |
+
+### Exports
+
+**Use named exports exclusively — no default exports.**
+
+```typescript
+// ❌ Avoid
+export default function ScoreCard() {}
+
+// ✅ Use
+export function ScoreCard() {}
+export const calcCaptionScore = () => {}
+```
+
+### CSS & Styling
+
+- Use **Tailwind CSS v4** utility classes for all layout and styling.
+- Do not add inline `style={{}}` props unless a value is genuinely dynamic (e.g., computed from data at runtime). Use Tailwind classes for static styles.
+- Mobile-first responsive design — start with mobile layout, add breakpoints for larger screens.
+
+### Formatting
+
+- **No linter config file** is committed — TypeScript strict mode serves as the primary correctness gate. Run `npm run build` to check.
+- Prettier is the formatter. Match existing indentation (2 spaces) and quote style (single quotes for JS/TS, double quotes in JSX attributes).
+- Comment non-obvious scoring formulas and domain-specific logic. Keep comments factual and brief. Favour expressive code over comments — comments should explain *why*, not *what*.
+
+---
+
+## Testing
+
+The project uses **Vitest** for unit testing.
+
+```bash
+npm test           # Run all tests once (CI mode)
+npx vitest         # Run in watch mode during development
+```
+
+### What to test
+
+- **All scoring functions** (caption calculation, domain normalization, cross-era comparison) must have tests. Pure math is the highest-value test target.
+- **Parser functions** — HTML parsing, score extraction, ensemble name matching.
+- **Any new pure TypeScript utility** must ship with tests.
+- **React components** do not require tests unless explicitly asked.
+
+### Test conventions
+
+- Test files are colocated with the module they test: `foo.ts` → `foo.test.ts`.
+- Use `describe` blocks to group tests by function, `it` blocks for individual cases.
+- Follow the `it('should … when …')` naming pattern.
+- Import from `vitest`: `import { describe, it, expect } from 'vitest'`
+- Cover: empty/edge inputs, expected happy-path values, and numerical correctness (use `toBeCloseTo` for floating-point).
+- Use the test vectors in `data/wgi_caption_eras.js` to validate scoring formula implementations.
+- Do not test implementation details — test the observable contract of each function.
+
+---
+
+## Domain-Specific Guidance
+
+### Scoring Data
+
+- WGI caption eras are defined in `data/wgi_caption_eras.js` and `data/wgi_caption_eras_2021_patch.js`. These are the source of truth for scoring formulas.
+- Always use year-based era lookup to determine scoring structure — never hardcode caption names.
+- Cross-era comparison uses domain buckets (`music_effect`, `visual_effect`, `music_perf`, `visual_perf`).
+- 2021 has no effect captions — domain buckets will have gaps.
+
+### HTML Parsing
+
+- Score HTML files are in `data/scores/`. These are CompetitionSuite recaps.
+- Use `data-translate-number` attributes for score extraction (2019+). Fall back to `td.score` text content for 2015–2018.
+- Use `header-division-name` class for class headers (2023+). Fall back to inline style matching for earlier years.
+- Skip non-percussion divisions (e.g., "Winds Independent A").
+
+### Data Files
+
+- Per-show JSON files in `data/<year>/`.
+- `ensembles.json` is the global ensemble registry with name aliases.
+- Season metadata in `data/<year>/season.json`.
+
+---
+
+## What Not to Do
+
+- Do not add a backend, API routes, or server-side rendering. This is a static site.
+- Do not add a second test framework — Vitest is the only test runner.
+- Do not add `eslint` or `prettier` config files unless explicitly requested.
+- Do not remove `StrictMode`.
+- Do not use `any` to silence TypeScript errors — fix the type instead.
+- Do not commit `dist/` — it is in `.gitignore` and built by Cloudflare Pages CI.
+- Do not add `console.log` statements to committed code.
+- **Never run `grep`, `cat`, `find`, `sed`, `awk`, or chained pipes in Bash.** Use the dedicated tools instead: `Grep` to search file contents, `Read` to read files, `Glob` to find files by pattern. Reserve Bash exclusively for operations that require shell execution (`git`, `gh`, `npm`, system commands).
+- Do not push directly to `main` — always use a feature branch and open a pull request.


### PR DESCRIPTION
## Summary
- Add CLAUDE.md with project conventions, TypeScript/React code style, testing rules, and domain-specific guidance for WGI scoring and CompetitionSuite HTML parsing
- Add TypeScript style guide, status line command, and three skills (create-feature, fix-bug, teach-lesson)
- Update settings.json with max output tokens and skill-creator plugin

Adapted from briangbrown/pickleball-lab .claude configuration, with all content rewritten for the drumline-scores project.

## Test plan
- [ ] Verify CLAUDE.md renders correctly on GitHub
- [ ] Verify skills are available via `/create-feature`, `/fix-bug`, `/teach-lesson`
- [ ] Verify status line displays correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)