### PR TITLE
Add vitest config, PWA manifest, code review workflow, and vite improvements

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,29 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+
+jobs:
+  claude-review:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code Review
+        id: claude-review
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
+          plugins: 'code-review@claude-code-plugins'
+          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'

--- a/index.html
+++ b/index.html
@@ -3,6 +3,8 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="theme-color" content="#080812" />
+    <link rel="manifest" href="/manifest.json" />
     <title>RMPA Score Tracker</title>
   </head>
   <body>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,24 @@
+{
+  "id": "/",
+  "name": "RMPA Score Tracker",
+  "short_name": "ScoreTracker",
+  "description": "Drumline score visualization and tracking for the RMPA circuit",
+  "display": "standalone",
+  "start_url": "/",
+  "background_color": "#080812",
+  "theme_color": "#080812",
+  "icons": [
+    {
+      "src": "/icon-192.png",
+      "sizes": "192x192",
+      "type": "image/png",
+      "purpose": "maskable any"
+    },
+    {
+      "src": "/icon-512.png",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "maskable any"
+    }
+  ]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,14 @@
+import path from 'node:path'
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 
 export default defineConfig({
   plugins: [tailwindcss(), react()],
+  server: { host: true },
+  resolve: {
+    alias: {
+      '@': path.resolve(import.meta.dirname, './src'),
+    },
+  },
 })

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    include: ['src/**/*.test.ts'],
+    coverage: {
+      provider: 'v8',
+      include: ['src/**/*.{ts,tsx}'],
+      exclude: [
+        '**/*.test.ts',
+        '**/*.test.tsx',
+        'src/**/*.tsx',
+        'src/main.tsx',
+      ],
+      thresholds: {
+        lines: 80,
+        functions: 80,
+        branches: 80,
+        statements: 80,
+      },
+    },
+  },
+})


### PR DESCRIPTION
## Summary
- **vitest.config.ts**: Separate config with 80% coverage thresholds, v8 provider, src include/exclude patterns
- **public/manifest.json**: PWA manifest for installable app (standalone display, dark theme colors matching prototype)
- **index.html**: Manifest link + theme-color meta tag
- **vite.config.ts**: `server.host: true` for devcontainer/codespaces access, `@` path alias for cleaner imports
- **claude-code-review.yml**: Automated PR review via Claude Code Action on all PRs

## Notes
- PWA manifest references icon-192.png and icon-512.png which don't exist yet — icons need to be created
- Coverage thresholds won't be enforced until there are non-trivial source files to cover

## Test plan
- [x] `npm test` passes
- [x] `npm run build` passes
- [ ] Verify dev server accessible in devcontainer via `npm run dev`

🤖 Generated with [Claude Code](https://claude.com/claude-code)