### PR TITLE
Fix: My ensemble isn't discoverable

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useCallback } from 'react'
+import { useEffect, useCallback, useRef, useState } from 'react'
 import { Layout } from './layout'
 import { useRoute } from './hooks/use-route'
 import { useSeasonData } from './hooks/use-season-data'
@@ -15,6 +15,8 @@ export function App() {
   const { route, setClassId, setView, setShowId, updateRoute } = useRoute()
   const { years, season, shows, isLoading, error } = useSeasonData(route.year)
   const { favorite, favoriteNames, toggleFavorite, removeFavorite } = useFavorite()
+  const myEnsembleRef = useRef<HTMLButtonElement>(null)
+  const [isMyEnsembleFlashing, setIsMyEnsembleFlashing] = useState(false)
 
   // When year changes, reset class and show selection
   const handleYearChange = useCallback((year: number) => {
@@ -33,10 +35,19 @@ export function App() {
     updateRoute({ classId, view: 'standings' })
   }, [updateRoute])
 
-  // Toggle favorite from standings view
+  // Toggle favorite — flash My Ensemble chip when a new favorite is set
   const handleToggleFavorite = useCallback((ensembleName: string) => {
+    const wasFavorited = favoriteNames.has(ensembleName)
     toggleFavorite(ensembleName, route.classId)
-  }, [toggleFavorite, route.classId])
+    if (!wasFavorited) {
+      // Wait for the pill to render, then scroll + flash
+      requestAnimationFrame(() => {
+        myEnsembleRef.current?.scrollIntoView({ behavior: 'smooth', block: 'nearest', inline: 'nearest' })
+        setIsMyEnsembleFlashing(true)
+        setTimeout(() => setIsMyEnsembleFlashing(false), 1200)
+      })
+    }
+  }, [toggleFavorite, route.classId, favoriteNames])
 
   // Get shows filtered to the selected class
   const classShows = shows
@@ -71,6 +82,8 @@ export function App() {
       onViewChange={setView}
       favorite={favorite}
       onShowMyEnsemble={() => updateRoute({ classId: '' })}
+      myEnsembleRef={myEnsembleRef}
+      isMyEnsembleFlashing={isMyEnsembleFlashing}
     >
       {isLoading && <Loading />}
       {error && <ErrorMessage message={error} />}

--- a/src/components/pill.tsx
+++ b/src/components/pill.tsx
@@ -1,18 +1,23 @@
+import type { Ref } from 'react'
+
 type PillProps = {
   label: string
   isActive: boolean
   onClick: () => void
+  ref?: Ref<HTMLButtonElement>
+  isFlashing?: boolean
 }
 
-export function Pill({ label, isActive, onClick }: PillProps) {
+export function Pill({ label, isActive, onClick, ref, isFlashing }: PillProps) {
   return (
     <button
+      ref={ref}
       onClick={onClick}
       className={`rounded-full px-3 py-1 text-xs font-medium transition-colors cursor-pointer whitespace-nowrap ${
         isActive
           ? 'bg-accent text-bg'
           : 'bg-surface-alt text-text-secondary hover:text-text-primary'
-      }`}
+      } ${isFlashing ? 'pill-flash' : ''}`}
     >
       {label}
     </button>

--- a/src/index.css
+++ b/src/index.css
@@ -51,3 +51,17 @@ body {
 *::-webkit-scrollbar-thumb:hover {
   background: var(--color-text-muted);
 }
+
+/* My Ensemble pill flash animation */
+@keyframes pill-flash {
+  0%, 100% {
+    box-shadow: 0 0 0 0 transparent;
+  }
+  25%, 75% {
+    box-shadow: 0 0 0 2px var(--color-accent);
+  }
+}
+
+.pill-flash {
+  animation: pill-flash 1.2s ease-in-out;
+}

--- a/src/layout.tsx
+++ b/src/layout.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react'
+import type { ReactNode, Ref } from 'react'
 import { Pill } from './components/pill'
 import type { SeasonMetadata } from './types'
 import type { ViewType } from './router'
@@ -15,6 +15,8 @@ type LayoutProps = {
   onViewChange: (view: ViewType) => void
   favorite: FavoriteEnsemble | null
   onShowMyEnsemble: () => void
+  myEnsembleRef?: Ref<HTMLButtonElement>
+  isMyEnsembleFlashing?: boolean
   children: ReactNode
 }
 
@@ -29,6 +31,8 @@ export function Layout({
   onViewChange,
   favorite,
   onShowMyEnsemble,
+  myEnsembleRef,
+  isMyEnsembleFlashing,
   children,
 }: LayoutProps) {
   const classes = season?.classes ?? []
@@ -63,6 +67,8 @@ export function Layout({
                 label={`\u2605 My Ensemble`}
                 isActive={!classId}
                 onClick={onShowMyEnsemble}
+                ref={myEnsembleRef}
+                isFlashing={isMyEnsembleFlashing}
               />
             )}
             {classes.map((cls) => (


### PR DESCRIPTION
Closes #24.

## What changed
- When starring an ensemble, the "★ My Ensemble" chip scrolls into view and flashes its outline with an animated accent-colored glow
- Added `isFlashing` and `ref` props to the Pill component
- CSS keyframe animation pulses a `box-shadow` outline over 1.2s then returns to normal

## How it was verified
- All tests pass
- Build succeeds
- Flash only triggers when setting a favorite (not when removing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)