### PR TITLE
Fix: Add share icon

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -10,6 +10,7 @@ import { MyEnsembleView } from './views/my-ensemble'
 import { Loading, ErrorMessage } from './components/loading'
 import { InstallBanner } from './components/install-banner'
 import { OfflineIndicator } from './components/offline-indicator'
+import { ToastProvider } from './components/toast'
 
 export function App() {
   const { route, setClassId, setView, setShowId, updateRoute } = useRoute()
@@ -138,6 +139,7 @@ export function App() {
         </div>
       )}
     </Layout>
+    <ToastProvider />
     </>
   )
 }

--- a/src/components/share-button.tsx
+++ b/src/components/share-button.tsx
@@ -1,0 +1,31 @@
+import { showToast } from './toast'
+
+export function ShareButton() {
+  const handleShare = async () => {
+    const url = window.location.href
+    try {
+      await navigator.clipboard.writeText(url)
+      showToast('Link copied to clipboard')
+    } catch {
+      showToast('Could not copy link')
+    }
+  }
+
+  return (
+    <button
+      onClick={handleShare}
+      className="p-1.5 rounded-lg text-text-secondary hover:text-text-primary hover:bg-surface-alt transition-colors cursor-pointer"
+      aria-label="Share"
+      title="Copy link to clipboard"
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 20 20"
+        fill="currentColor"
+        className="h-5 w-5"
+      >
+        <path d="M13 4.5a2.5 2.5 0 1 1 .702 1.737L6.97 9.604a2.518 2.518 0 0 1 0 .799l6.733 3.365a2.5 2.5 0 1 1-.671 1.341l-6.733-3.365a2.5 2.5 0 1 1 0-3.482l6.733-3.366A2.52 2.52 0 0 1 13 4.5Z" />
+      </svg>
+    </button>
+  )
+}

--- a/src/components/toast.tsx
+++ b/src/components/toast.tsx
@@ -1,0 +1,45 @@
+import { useState, useEffect, useCallback } from 'react'
+
+type Toast = {
+  id: number
+  message: string
+}
+
+let toastId = 0
+let addToastGlobal: ((message: string) => void) | null = null
+
+export function showToast(message: string) {
+  addToastGlobal?.(message)
+}
+
+export function ToastProvider() {
+  const [toasts, setToasts] = useState<Array<Toast>>([])
+
+  const addToast = useCallback((message: string) => {
+    const id = ++toastId
+    setToasts((prev) => [...prev, { id, message }])
+    setTimeout(() => {
+      setToasts((prev) => prev.filter((t) => t.id !== id))
+    }, 2500)
+  }, [])
+
+  useEffect(() => {
+    addToastGlobal = addToast
+    return () => { addToastGlobal = null }
+  }, [addToast])
+
+  if (toasts.length === 0) return null
+
+  return (
+    <div className="fixed bottom-6 left-1/2 -translate-x-1/2 z-50 flex flex-col gap-2">
+      {toasts.map((toast) => (
+        <div
+          key={toast.id}
+          className="rounded-lg border border-border bg-surface px-4 py-2.5 text-sm text-text-primary shadow-lg animate-[toast-in_0.2s_ease-out]"
+        >
+          {toast.message}
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/src/index.css
+++ b/src/index.css
@@ -110,3 +110,15 @@ body {
 .pill-flash {
   animation: pill-flash 1.2s ease-in-out;
 }
+
+/* Toast slide-in animation */
+@keyframes toast-in {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}

--- a/src/layout.tsx
+++ b/src/layout.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode, Ref } from 'react'
 import { Pill } from './components/pill'
 import { SettingsButton } from './components/settings-dialog'
+import { ShareButton } from './components/share-button'
 import type { SeasonMetadata } from './types'
 import type { ViewType } from './router'
 import type { FavoriteEnsemble } from './favorites'
@@ -46,7 +47,10 @@ export function Layout({
           <h1 className="text-lg font-bold text-accent tracking-tight">
             RMPA Score Tracker
           </h1>
-          <SettingsButton />
+          <div className="flex items-center gap-1">
+            <ShareButton />
+            <SettingsButton />
+          </div>
         </div>
 
         {/* Year selector */}


### PR DESCRIPTION
Closes #28.

## What changed
- Added share button (share icon) to the left of the gear icon in the header
- Clicking copies the current URL to the clipboard via `navigator.clipboard.writeText`
- Added toast notification system that shows "Link copied to clipboard" with a slide-in animation, auto-dismissing after 2.5s

## How it was verified
- All tests pass
- Build succeeds
- Toast appears and auto-dismisses on click

🤖 Generated with [Claude Code](https://claude.com/claude-code)