### PR TITLE
fix: use network-first for navigation to prevent stale app shell

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -7,7 +7,7 @@
 //   Images/icons:                     cache-first
 // ---------------------------------------------------------------------------
 
-const CACHE_NAME = 'rmpa-v1'
+const CACHE_NAME = 'rmpa-v2'
 const DATA_CACHE_NAME = 'rmpa-data-v1'
 
 // App shell files to precache (populated at build time via manifest)
@@ -58,7 +58,13 @@ self.addEventListener('fetch', (event) => {
     return
   }
 
-  // App shell and assets — cache-first with network fallback
+  // Navigation requests (HTML pages) — network-first so new deploys are picked up
+  if (event.request.mode === 'navigate') {
+    event.respondWith(networkFirstWithCache(event.request, CACHE_NAME))
+    return
+  }
+
+  // Static assets (JS, CSS, images) — cache-first (filenames are content-hashed)
   event.respondWith(cacheFirstWithNetwork(event.request, CACHE_NAME))
 })
 


### PR DESCRIPTION
## Summary
- The service worker was using cache-first for **all** app shell requests, including HTML navigation. After a deploy, normal refresh kept serving the old cached `index.html` which referenced old JS/CSS bundles — so new features (like the share/gear icons) disappeared.
- Navigation requests now use **network-first**, so the latest HTML is always fetched. Static assets (JS, CSS, images) remain cache-first since their filenames are content-hashed by Vite.
- Bumped cache name from `rmpa-v1` to `rmpa-v2` so existing users get a fresh cache on the next visit.

## Test plan
- [ ] Deploy, open the site, verify icons appear
- [ ] Refresh normally — icons should persist
- [ ] Go offline — cached version should still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)