### PR TITLE
Fix: recharts -1 size error

### DIFF
--- a/src/views/cross-season.tsx
+++ b/src/views/cross-season.tsx
@@ -165,7 +165,7 @@ export function CrossSeasonView({ initialEnsemble }: CrossSeasonViewProps) {
           {/* Score Trajectory Chart */}
           <Panel title="Score Trajectory">
             <div className="h-[300px] sm:h-[350px]">
-              <ResponsiveContainer width="100%" height="100%">
+              <ResponsiveContainer width="100%" height="100%" minWidth={0}>
                 <LineChart data={chartData} margin={{ top: 5, right: 10, bottom: 5, left: 0 }}>
                   <CartesianGrid strokeDasharray="3 3" stroke="var(--color-border-grid)" />
                   <XAxis

--- a/src/views/progression.tsx
+++ b/src/views/progression.tsx
@@ -165,7 +165,7 @@ export function ProgressionView({ shows, highlight, favoriteNames, onToggleFavor
       {/* Progression Chart */}
       <Panel title={`${activeCaption} Progression`}>
         <div className="h-[300px] sm:h-[400px]">
-          <ResponsiveContainer width="100%" height="100%">
+          <ResponsiveContainer width="100%" height="100%" minWidth={0}>
             <LineChart data={chartData} margin={{ top: 5, right: 5, bottom: 5, left: 0 }}>
               <CartesianGrid strokeDasharray="3 3" stroke="var(--color-border-grid)" />
               <XAxis

--- a/src/views/standings.tsx
+++ b/src/views/standings.tsx
@@ -140,7 +140,7 @@ export function StandingsView({
           {/* Score Comparison Bar Chart */}
           <Panel title="Score Comparison">
             <div className="h-[250px] sm:h-[300px]">
-              <ResponsiveContainer width="100%" height="100%">
+              <ResponsiveContainer width="100%" height="100%" minWidth={0}>
                 <BarChart
                   data={comparisonData}
                   layout="vertical"
@@ -179,7 +179,7 @@ export function StandingsView({
           {captionNames.length > 0 && (
             <Panel title="Caption Breakdown">
               <div className="h-[250px] sm:h-[300px]">
-                <ResponsiveContainer width="100%" height="100%">
+                <ResponsiveContainer width="100%" height="100%" minWidth={0}>
                   <BarChart
                     data={captionData}
                     layout="vertical"


### PR DESCRIPTION
Closes #35.

## What changed
- Added `minWidth={0}` to all 4 `ResponsiveContainer` instances across progression, standings, and cross-season views
- This prevents Recharts from computing `-1` dimensions when the container hasn't been laid out yet

## How it was verified
- All tests pass
- Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)