### PR TITLE
chore: rebrand to Drumline Scores, add disclaimer

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
     <link rel="icon" href="/favicon.ico" sizes="32x32" />
     <link rel="manifest" href="/manifest.json" />
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
-    <title>RMPA Score Tracker</title>
+    <title>Drumline Scores</title>
   </head>
   <body>
     <div id="root"></div>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "/",
-  "name": "RMPA Score Tracker",
-  "short_name": "ScoreTracker",
+  "name": "Drumline Scores",
+  "short_name": "Drumline",
   "description": "Drumline score visualization and tracking for the RMPA circuit",
   "display": "standalone",
   "start_url": "/",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,5 +1,5 @@
 // ---------------------------------------------------------------------------
-// Service Worker — RMPA Score Tracker
+// Service Worker — Drumline Scores
 //
 // Cache strategies:
 //   App shell (HTML, CSS, JS, fonts): cache-first

--- a/src/components/install-banner.tsx
+++ b/src/components/install-banner.tsx
@@ -79,7 +79,7 @@ export function InstallBanner() {
     return (
       <div className="mx-auto max-w-[920px] px-4 mb-4">
         <div className="flex items-center justify-between rounded-lg border border-accent/30 bg-accent/10 px-4 py-3 text-xs">
-          <span>Install RMPA Score Tracker for quick access</span>
+          <span>Install Drumline Scores for quick access</span>
           <div className="flex items-center gap-2 ml-3">
             <button
               onClick={handleInstall}

--- a/src/layout.tsx
+++ b/src/layout.tsx
@@ -45,9 +45,12 @@ export function Layout({
       {/* Header */}
       <header className="mb-6">
         <div className="flex items-center justify-between">
-          <h1 className="text-lg font-bold text-accent tracking-tight">
-            RMPA Score Tracker
-          </h1>
+          <a
+            href="#/"
+            className="text-lg font-bold text-accent tracking-tight hover:text-accent/80 transition-colors"
+          >
+            Drumline Scores
+          </a>
           <div className="flex items-center gap-1">
             <ShareButton />
             <SettingsButton />
@@ -122,6 +125,19 @@ export function Layout({
 
       {/* Main content */}
       <main>{children}</main>
+
+      {/* Disclaimer */}
+      <footer className="mt-8 pb-6 text-center text-xs text-text-muted">
+        Scores are unofficial. For official scores visit{' '}
+        <a
+          href="https://rmpa.org/scores"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="underline hover:text-text-secondary transition-colors"
+        >
+          rmpa.org/scores
+        </a>
+      </footer>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- Renamed "RMPA Score Tracker" → "Drumline Scores" across header, HTML title, manifest, install banner, and service worker
- Header title is now a clickable link back to root (`#/`)
- Added footer disclaimer on all pages: "Scores are unofficial. For official scores visit [rmpa.org/scores](https://rmpa.org/scores)"

## Test plan
- [ ] Header shows "Drumline Scores" and links to root
- [ ] Footer disclaimer visible on all views
- [ ] rmpa.org/scores link opens in new tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)