### PR TITLE
Remove IPv6 disable argument from devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,6 @@
   "features": {
     "ghcr.io/devcontainers/features/github-cli:1": {}
   },
-  "runArgs": ["--sysctl", "net.ipv6.conf.all.disable_ipv6=1"],
   "containerEnv": {
     "ANTHROPIC_API_KEY": "${localEnv:ANTHROPIC_API_KEY}",
     "GH_TOKEN": "${localEnv:GH_TOKEN}"


### PR DESCRIPTION
Codespaces doesn't allow disabling IPV6. This was just to get the Claude Code login to work smoothly, but you can work around it.