### PR TITLE
chore: add .DS_Store and .claude/settings.local.json to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,9 @@ dist
 # Vite logs files
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
+
+# Claude local settings
+.claude/settings.local.json
+
+# Mac Finder metadata
+.DS_Store


### PR DESCRIPTION
## Summary
- Add `.DS_Store` (Mac Finder metadata) to .gitignore
- Add `.claude/settings.local.json` (Claude Code local settings) to .gitignore

## Test plan
- [x] No code changes — gitignore only

🤖 Generated with [Claude Code](https://claude.com/claude-code)