### PR TITLE
Fix: Progression chart ensemble labels overflow

### DIFF
--- a/src/views/progression.tsx
+++ b/src/views/progression.tsx
@@ -166,7 +166,7 @@ export function ProgressionView({ shows, highlight, favoriteNames, onToggleFavor
               />
               <Tooltip content={<ChartTooltip />} />
               <Legend
-                wrapperStyle={{ fontSize: 10, color: 'var(--color-text-secondary)' }}
+                wrapperStyle={{ fontSize: 10, color: 'var(--color-text-secondary)', paddingLeft: 35 }}
                 formatter={(value: string) => shortNameMap.get(value) ?? value}
               />
               {ensembleNames.map((name) => (


### PR DESCRIPTION
Closes #62.

## What changed
- Added `paddingLeft: 35` to the Legend wrapper style to counteract the chart's `left: -35` margin, keeping ensemble labels centered within the container bounds

## How it was verified
- All tests pass
- Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)