### PR TITLE
feat: pipeline Phase 1 — core modules

### DIFF
--- a/data/test-fixtures/rmpa-competitions-page.html
+++ b/data/test-fixtures/rmpa-competitions-page.html
@@ -1,0 +1,591 @@
+<!doctype html>
+<!--[if lt IE 7]>      <html class="no-js lt-ie9 lt-ie8 lt-ie7" lang=""> <![endif]-->
+<!--[if IE 7]>         <html class="no-js lt-ie9 lt-ie8" lang=""> <![endif]-->
+<!--[if IE 8]>         <html class="no-js lt-ie9" lang=""> <![endif]-->
+<!--[if gt IE 8]><!--> <html class="no-js" lang=""> <!--<![endif]-->
+    <head>
+        <meta charset="utf-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+        <title>RMPA</title>
+        <meta name="description" content="">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <!-- <link rel="apple-touch-icon" href="//rmpa.org/apple-touch-icon.png"> -->
+        <link rel="shortcut icon" type="image/x-icon" href="/favicon.png" />
+
+        <!-- link href='https://fonts.googleapis.com/css?family=Oswald:400,300' rel='stylesheet' type='text/css' -->
+        <!-- <link rel="stylesheet" href="//rmpa.org/theme/main/assets/fonts/stylesheet.css"> -->
+        <link href="https://fonts.googleapis.com/css?family=Oswald:200|Raleway:400,800&display=swap" rel="stylesheet">
+        <link rel="stylesheet" href="//rmpa.org/theme/main/assets/css/bootstrap.min.css?v=2">
+        <link rel="stylesheet" href="//rmpa.org/theme/main/assets/css/main.css?v=309">
+        <link rel="stylesheet" href="//rmpa.org/theme/main/assets/css/print.css?v=387" media="print">
+
+        <!--[if lt IE 9]>
+            <script src="js/vendor/html5-3.6-respond-1.4.2.min.js"></script>
+        <![endif]-->
+
+        <!-- <script src="https://kit.fontawesome.com/36bf5b8bef.js"></script> -->
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css">
+    </head>
+    <body class="home">
+        <!--[if lt IE 8]>
+            <p class="browserupgrade">You are using an <strong>outdated</strong> browser. Please <a href="http://browsehappy.com/">upgrade your browser</a> to improve your experience.</p>
+        <![endif]-->
+
+
+        <header>
+            <nav class="navbar navbar-dark fixed-top">
+                <a class="navbar-brand" href="/"><img src="/theme/main/assets/images/rmpa_logo_header.png" class="mw-100" /></a>
+                
+                <div class="float-right text-right">
+                    <!-- <a class="newsletter-signup text-white" href="#" style="text-decoration: none; font-size: 20px; display: inline-block; padding: 15px 5px;">Newsletter</a> -->
+                    <a class="ensemble-search text-white" href="#" style="font-size: 20px; display: inline-block; padding: 0 0 0 10px;">
+                        <i class="bi bi-search"></i>    
+                        <!-- <i class="fas fa-search"></i> -->
+                    </a>
+                    <a class="ensemble-login text-white" href="#" style="font-size: 20px; display: inline-block; padding: 0 0 0 10px;">
+                        <i class="bi bi-person"></i>    
+                        <!-- <i class="fas fa-user-circle"></i> -->
+                    </a>
+                    <a class="show-nav-modal text-white" href="#" style="font-size: 20px; display: inline-block; padding: 0 0 0 10px;">
+                        <i class="bi bi-list"></i>    
+                        <!-- <i class="fas fa-bars"></i> -->
+                    </a>
+                </div>
+            </nav>
+
+            <div class="collapse" id="navigation">
+                <div class="text-center">
+                    <h2><a href="/about/our-story" class="load-about">About</a></h2>
+                    <h2><a href="/news">News</a></h2>
+                    <h2><a href="/calendar">Calendar</a></h2>
+                    <h2><a href="/scores">Scores</a></h2>
+                    <h2><a href="/competitions">Competitions</a></h2>
+                    <h2><a href="/education">Education</a></h2>
+                    <h2><a target="_blank" href="https://rmpamarketplace.square.site">Donate</a></h2>
+                    <!-- <h2><a href="https://www.coloradogives.org/index.php?section=organizations&action=newDonation&fwID=39858" target="_blank">Donate</a></h2> -->
+                    <h2><a href="/register">Registration</a></h2>
+                    <!-- <h2><a href="/about/virtualsolocompetition">Virtual Solo Competition</a></h2> -->
+                </div>
+            </div>
+        </header>
+
+        <main role="main">
+
+            
+
+<div class="container">
+    <div class="main-top-pad">
+        <h1 class="big-block">Competitions</h1>
+        
+        <div class="row justify-content-md-center">
+            <div class="col col-md-6 mx-auto">
+                                    <div class="row">
+                        <div class="col-md-12 col-12">
+                            <p>
+                                <small><em>02/14/26 Sat</em></small><br />
+                                <a href="/competitions/event/43" class="view-info comp-43"><span class="larger">Monarch HS</span></a>
+                            </p>
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div class="col-md-2 col-4">
+                            <p class="text-md-center text-left pt-2">
+                                                                    <a href="https://schedules.competitionsuite.com/c57c1154-00fa-4207-914f-518a2835033b_standard.htm" target="_blank">Schedule</a>
+                                                            </p>
+                        </div>
+                        <div class="col-md-2 col-4">
+                            <p class="text-md-center text-left pt-2">
+                                                                    <a href="https://schedules.competitionsuite.com/c57c1154-00fa-4207-914f-518a2835033b_logistical.htm" target="_blank">Logistics</a>
+                                                            </p>
+                        </div>
+                        
+                        <div class="col-md-2 col-4">
+                            <p class="text-md-center text-left pt-2">
+                                                                    <a href="/admin/system/files/layout/Monarch Gym 2026.pdf" target="_blank">Layout</a>
+                                                            </p>
+                        </div>
+                        <div class="col-md-4 col-4">
+                            <p class="text-md-center text-left pt-2">
+                                                                    <a href="/admin/system/files/schedule/monarch-parking-lot-map_v3.pdf" target="_blank">Warmup&nbsp;Zones</a>
+                                                            </p>
+                        </div>
+                        
+                        <div class="col-md-2 col-4">
+                            <p class="text-md-center text-left pt-2">
+                                                                    <a href="https://goo.gl/maps/XWxA6mPBRt5zP3R26" target="_blank">Map</a>
+                                                            </p>
+                        </div>
+                        
+                    </div>
+                    <hr class="mt-0 pt-0" />
+                                    <div class="row">
+                        <div class="col-md-12 col-12">
+                            <p>
+                                <small><em>02/21/26 Sat</em></small><br />
+                                <a href="/competitions/event/35" class="view-info comp-35"><span class="larger">Frederick HS</span></a>
+                            </p>
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div class="col-md-2 col-4">
+                            <p class="text-md-center text-left pt-2">
+                                                                    <a href="https://schedules.competitionsuite.com/82dd7de4-8c42-4842-9cd4-ccabdaf26c19_standard.htm" target="_blank">Schedule</a>
+                                                            </p>
+                        </div>
+                        <div class="col-md-2 col-4">
+                            <p class="text-md-center text-left pt-2">
+                                                                    <a href="https://schedules.competitionsuite.com/82dd7de4-8c42-4842-9cd4-ccabdaf26c19_logistical.htm" target="_blank">Logistics</a>
+                                                            </p>
+                        </div>
+                        
+                        <div class="col-md-2 col-4">
+                            <p class="text-md-center text-left pt-2">
+                                                                    <a href="/admin/system/files/layout/Fred Gym Map.pdf" target="_blank">Layout</a>
+                                                            </p>
+                        </div>
+                        <div class="col-md-4 col-4">
+                            <p class="text-md-center text-left pt-2">
+                                                                    <a href="/admin/system/files/schedule/fred-2026.pdf" target="_blank">Warmup&nbsp;Zones</a>
+                                                            </p>
+                        </div>
+                        
+                        <div class="col-md-2 col-4">
+                            <p class="text-md-center text-left pt-2">
+                                                                    <a href="https://maps.app.goo.gl/MwHXwePQdNuxpvVBA" target="_blank">Map</a>
+                                                            </p>
+                        </div>
+                        
+                    </div>
+                    <hr class="mt-0 pt-0" />
+                                    <div class="row">
+                        <div class="col-md-12 col-12">
+                            <p>
+                                <small><em>02/28/26 Sat</em></small><br />
+                                <a href="/competitions/event/39" class="view-info comp-39"><span class="larger">Lakewood HS</span></a>
+                            </p>
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div class="col-md-2 col-4">
+                            <p class="text-md-center text-left pt-2">
+                                                                    <a href="https://schedules.competitionsuite.com/0bf510d3-f18c-4b8d-b56b-994ed7f28737_standard.htm" target="_blank">Schedule</a>
+                                                            </p>
+                        </div>
+                        <div class="col-md-2 col-4">
+                            <p class="text-md-center text-left pt-2">
+                                                                    <a href="https://schedules.competitionsuite.com/0bf510d3-f18c-4b8d-b56b-994ed7f28737_logistical.htm" target="_blank">Logistics</a>
+                                                            </p>
+                        </div>
+                        
+                        <div class="col-md-2 col-4">
+                            <p class="text-md-center text-left pt-2">
+                                                                    <a href="/admin/system/files/layout/Lakewood Gym Map (2).pdf" target="_blank">Layout</a>
+                                                            </p>
+                        </div>
+                        <div class="col-md-4 col-4">
+                            <p class="text-md-center text-left pt-2">
+                                                                    <a href="/admin/system/files/schedule/lakewood-rmpa-show-map-2026.pdf" target="_blank">Warmup&nbsp;Zones</a>
+                                                            </p>
+                        </div>
+                        
+                        <div class="col-md-2 col-4">
+                            <p class="text-md-center text-left pt-2">
+                                                                    <a href="https://www.google.com/maps/place/Lakewood+High+School/@39.7282615,-105.1063444,15z/data=!4m5!3m4!1s" target="_blank">Map</a>
+                                                            </p>
+                        </div>
+                        
+                    </div>
+                    <hr class="mt-0 pt-0" />
+                                    <div class="row">
+                        <div class="col-md-12 col-12">
+                            <p>
+                                <small><em>03/07/26 Sat</em></small><br />
+                                <a href="/competitions/event/45" class="view-info comp-45"><span class="larger">Legacy HS</span></a>
+                            </p>
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div class="col-md-2 col-4">
+                            <p class="text-md-center text-left pt-2">
+                                                                    <a href="https://schedules.competitionsuite.com/aac777fc-0cd0-43cc-b608-27c9862dee6c_standard.htm" target="_blank">Schedule</a>
+                                                            </p>
+                        </div>
+                        <div class="col-md-2 col-4">
+                            <p class="text-md-center text-left pt-2">
+                                                                    <a href="https://schedules.competitionsuite.com/aac777fc-0cd0-43cc-b608-27c9862dee6c_logistical.htm" target="_blank">Logistics</a>
+                                                            </p>
+                        </div>
+                        
+                        <div class="col-md-2 col-4">
+                            <p class="text-md-center text-left pt-2">
+                                                                    <a href="/admin/system/files/layout/Legacy Floor Map 2026.pdf" target="_blank">Layout</a>
+                                                            </p>
+                        </div>
+                        <div class="col-md-4 col-4">
+                            <p class="text-md-center text-left pt-2">
+                                                                    <a href="/admin/system/files/schedule/legacy-2026.png" target="_blank">Warmup&nbsp;Zones</a>
+                                                            </p>
+                        </div>
+                        
+                        <div class="col-md-2 col-4">
+                            <p class="text-md-center text-left pt-2">
+                                                                    <a href="https://www.google.com/maps/place/Legacy+High+School/@39.944041,-105.019448,15z/data=!4m6!3m5!1s0x87" target="_blank">Map</a>
+                                                            </p>
+                        </div>
+                        
+                    </div>
+                    <hr class="mt-0 pt-0" />
+                                    <div class="row">
+                        <div class="col-md-12 col-12">
+                            <p>
+                                <small><em>03/21/26 Sat</em></small><br />
+                                <a href="/competitions/event/47" class="view-info comp-47"><span class="larger">Longmont HS</span></a>
+                            </p>
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div class="col-md-2 col-4">
+                            <p class="text-md-center text-left pt-2">
+                                                                    <a href="https://schedules.competitionsuite.com/6f9d5429-efb7-40e1-8ffc-2358461e31b9_standard.htm" target="_blank">Schedule</a>
+                                                            </p>
+                        </div>
+                        <div class="col-md-2 col-4">
+                            <p class="text-md-center text-left pt-2">
+                                                                    <a href="https://schedules.competitionsuite.com/6f9d5429-efb7-40e1-8ffc-2358461e31b9_logistical.htm" target="_blank">Logistics</a>
+                                                            </p>
+                        </div>
+                        
+                        <div class="col-md-2 col-4">
+                            <p class="text-md-center text-left pt-2">
+                                                                    <a href="/admin/system/files/layout/Longmont HS Gym Layout.pdf" target="_blank">Layout</a>
+                                                            </p>
+                        </div>
+                        <div class="col-md-4 col-4">
+                            <p class="text-md-center text-left pt-2">
+                                                                    <a href="/admin/system/files/schedule/longmont-hs-parking-lot-map---6-zones.pdf" target="_blank">Warmup&nbsp;Zones</a>
+                                                            </p>
+                        </div>
+                        
+                        <div class="col-md-2 col-4">
+                            <p class="text-md-center text-left pt-2">
+                                                                    <a href="https://goo.gl/maps/yunvLjiRjL5PVRrH6" target="_blank">Map</a>
+                                                            </p>
+                        </div>
+                        
+                    </div>
+                    <hr class="mt-0 pt-0" />
+                                    <div class="row">
+                        <div class="col-md-12 col-12">
+                            <p>
+                                <small><em>03/28/26 Sat</em></small><br />
+                                <a href="/competitions/event/41" class="view-info comp-41"><span class="larger">Championship Prelims @ Mountain Range HS</span></a>
+                            </p>
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div class="col-md-2 col-4">
+                            <p class="text-md-center text-left pt-2">
+                                                                    <a href="https://schedules.competitionsuite.com/0f16a087-a3d0-44f5-bbc4-ea22f64384b0_standard.htm" target="_blank">Schedule</a>
+                                                            </p>
+                        </div>
+                        <div class="col-md-2 col-4">
+                            <p class="text-md-center text-left pt-2">
+                                                                    <a href="https://schedules.competitionsuite.com/0f16a087-a3d0-44f5-bbc4-ea22f64384b0_logistical.htm" target="_blank">Logistics</a>
+                                                            </p>
+                        </div>
+                        
+                        <div class="col-md-2 col-4">
+                            <p class="text-md-center text-left pt-2">
+                                                                    <a href="/admin/system/files/layout/Mountain Range HS Gym Layout.pdf" target="_blank">Layout</a>
+                                                            </p>
+                        </div>
+                        <div class="col-md-4 col-4">
+                            <p class="text-md-center text-left pt-2">
+                                                                    <a href="/admin/system/files/schedule/mountain-range-hs-parking-lot-map-6-zones.pdf" target="_blank">Warmup&nbsp;Zones</a>
+                                                            </p>
+                        </div>
+                        
+                        <div class="col-md-2 col-4">
+                            <p class="text-md-center text-left pt-2">
+                                                                    <a href="https://goo.gl/maps/LVpeUDRAXmBsU3LBA" target="_blank">Map</a>
+                                                            </p>
+                        </div>
+                        
+                    </div>
+                    <hr class="mt-0 pt-0" />
+                                    <div class="row">
+                        <div class="col-md-12 col-12">
+                            <p>
+                                <small><em>04/04/26 Sat</em></small><br />
+                                <a href="/competitions/event/49" class="view-info comp-49"><span class="larger">Championships Finals @ Denver Coliseum</span></a>
+                            </p>
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div class="col-md-2 col-4">
+                            <p class="text-md-center text-left pt-2">
+                                                                    <a href="https://schedules.competitionsuite.com/f74cc554-fe45-407e-a848-a97bb4aac0d5_standard.htm" target="_blank">Schedule</a>
+                                                            </p>
+                        </div>
+                        <div class="col-md-2 col-4">
+                            <p class="text-md-center text-left pt-2">
+                                                                    <a href="https://schedules.competitionsuite.com/f74cc554-fe45-407e-a848-a97bb4aac0d5_logistical.htm" target="_blank">Logistics</a>
+                                                            </p>
+                        </div>
+                        
+                        <div class="col-md-2 col-4">
+                            <p class="text-md-center text-left pt-2">
+                                                                    <a href="/admin/system/files/layout/State Finals Performance Map.pdf" target="_blank">Layout</a>
+                                                            </p>
+                        </div>
+                        <div class="col-md-4 col-4">
+                            <p class="text-md-center text-left pt-2">
+                                                                    <a href="/admin/system/files/schedule/coliseum-map.pdf" target="_blank">Warmup&nbsp;Zones</a>
+                                                            </p>
+                        </div>
+                        
+                        <div class="col-md-2 col-4">
+                            <p class="text-md-center text-left pt-2">
+                                                                    <a href="https://goo.gl/maps/nS2JxJv7dTxsXAMs5" target="_blank">Map</a>
+                                                            </p>
+                        </div>
+                        
+                    </div>
+                    <hr class="mt-0 pt-0" />
+                            </div>
+        </div>
+
+        <input type="hidden" id="selected_comp_id" value="0" />
+
+    </div>
+</div>
+            <!-- SPONSORS -->
+            <div class="sponsors">
+
+                <div class="container">
+                    <h3 class="text-center text-md-left d-none d-md-block">SPONSORS</h3>
+                    <div class="row no-gutters">
+                    <div class="col"><a href="http://www.risearts.org" target="_blank"><img src="/admin/system/files/pa_primary_white_3000x1200.png" /></a></div><div class="col"><a href="http://springhillsuites.marriott.com" target="_blank"><img src="http://rmpa.org/admin/system/files/springhill.png" /></a></div><div class="col"><a href="https://www.denverpercussion.com/" target="_blank"><img src="/admin/system/files/Denver-Percussion-logo-WHT (2).png" /></a></div><div class="col"><a href="https://ascendperformingarts.org/" target="_blank"><img src="/admin/system/files/Ascend.png" /></a></div><div class="col"><a href="https://www.frolicbrewing.com/" target="_blank"><img src="/admin/system/files/Frolic Logo Male with Lettering.png" /></a></div>                    </div>
+                </div>
+
+            </div>
+
+        </main>
+
+        <!-- FOOTER -->
+        <footer class="container">
+            <div class="row">
+                <div class="col-md-2 text-center text-md-left">
+                    <a href="/" class="d-none d-md-block"><img src="/theme/main/assets/images/rmpa_logo_footer.png" class="mw-100" /></a>
+                </div>
+                <div class="col-md-2">
+                    &nbsp;
+                </div>
+                <div class="col-md-8">
+                    <div class="row">
+                                                <div class="col-md- col">
+                            <p class="">
+                                <strong>Information</strong><br />
+                                <a href="/about/by-laws">By-Laws</a><br />
+<a href="/about/meeting-notes">Meeting Minutes</a><br />
+<a href="mailto:rmpaboard@rmpa.org">Email the Board</a><br />
+<a href="https://docs.google.com/document/d/1F2Rxkw4xZsbHAyuWlE_Y4kBe8NHWqWHh/edit?usp=sharing&ouid=110078278136832113753&rtpof=true&sd=true">Become a Sponsor</a><br />
+<a href="/about/participant-protection">Participant Protection</a><br /><br />
+                            </p>
+                        </div>
+                                                <div class="col-md- col">
+                            <p class="">
+                                <strong>Awards</strong><br />
+                                <a href="/awards/hall-of-fame">Hall of Fame</a><br />
+<a href="/awards/espirit-de-corps">Espirit De Corps</a><br />
+<a href="/awards/most-improved">Most Improved</a><br />
+<a href="/awards/staff-volunteer-of-the-year">Staff/Volunteer of the Year</a>                            </p>
+                        </div>
+                                                <div class="col-md- col">
+                            <p class="">
+                                <strong>Social</strong><br />
+                                <a href="https://www.facebook.com/TheRMPA" target="_blank">Facebook</a><br />
+<a href="https://www.instagram.com/rmpa93" target="_blank">Instagram</a><br />                            </p>
+                        </div>
+                                            </div>
+                </div>
+            </div>
+        </footer>
+    
+        <!-- Modal -->
+        <div class="modal fade" id="my_modal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel">
+            <div class="modal-dialog" role="document">
+                <div class="modal-content">
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                        <i class="bi bi-x-lg"></i>
+                        <!-- <i class="fas fa-times"></i> -->
+                    </button>
+                    <div class="modal-body">
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Ensemble Search -->
+        <div class="ensemble-search-form hide-on-load">
+            <h1>Group Search</h1>
+
+            <div class="hide-on-load">
+                <input type="text" name="username" />
+                <input type="password" name="password" />
+            </div>
+
+            <div class="switch-sites-list">
+                <form method="post" action="//rmpa.org/main/load" id="view-ensemble">
+                    <input type="text" class="form-control typeahead-search" name="ensemble" placeholder="Type Name" />
+                </form>
+            </div>
+            <div id="site-list-login" class="hide-on-load">Alameda International HS,Arapahoe High School,Arvada High School,Bear Creek High School Percussion Ensemble,Black Diamond Percussion ,Blue Knights Percussion Ensemble,Blue Knights Winds,Broomfield High School,Burlington Cougar Drumline,Ca&ntilde;on City Tiger Pride Winter Percussion,Castle View in Douglas County,Centaurus Winter Percussion Ensemble,Chaparral High School Winter Percussion Ensemble,Columbine High School,Columbine High School,D'Evelyn Percussion Ensemble,D49indoor,Dakota Ridge High School,Dakota Ridge High School,Denver South Rebels,District 49 Winter Percussion,Doherty High School Percussion Ensemble,Douglas County High School Winter Percussion,Eaglecrest High School,Eaglecrest High School,Englewood High School Percussion Ensemble,Evergreen High School Winter Percussion,Fairivew High School ,Fossil Ridge Winter Percussion,Fountain-Fort Carson High School Percussion Ensemble,Gateway High School Percussion Ensemble,Great Oak High School,Harrison District 2 Percussion Ensemble,Heritage High School Winter Percussion,Highlands Ranch Falcon Percussion,Joeâ€™s test to help Burlington ,Lakewood Winter Percussion Ensemble,Legacy High School Winter Percussion,Legend Titan Percussion Ensemble,Longmont Winter Percussion,Loveland Indoor Percussion,Mesa Ridge Percussion Ensemble,Monarch Indoor Percussion,Mountain Range High School,Mountain Vista Percussion Ensemble,Pine Creek High School,Pomona High School Winds,Ponderosa High School,Prairie View High School,Pueblo Central High School ,Pueblo Central High School,Pueblo City Schools Indoor Percussion,Rampart High School,Rangeview High School,Rise Percussion,Rise Percussion Concert,Rise2,Rise2 Concert,Rock Canyon High School,Standley Lake High School,Test,Test,ThunderRidge High School,West High School Drumline,West High School Drumline,Wheat Ridge HS Winter Percussion,William J. Palmer High School,Windsor Percussion Ensemble </div>
+        </div>
+
+        <!-- About -->
+        <div class="about-page hide-on-load">
+            <h1>About</h1>
+            <div class="row">
+                <div class="col-12 col-lg-3 mb-3">
+                    <div class="nav flex-column nav-pills" id="v-pills-tab" role="tablist" aria-orientation="vertical">
+                        <a class="nav-link active" id="v-pills-home-tab" data-toggle="pill" href="#v-pills-home" role="tab" aria-controls="v-pills-home" aria-selected="true">Who We Are</a>
+                        <a class="nav-link" id="v-pills-profile-tab" data-toggle="pill" href="#v-pills-profile" role="tab" aria-controls="v-pills-profile" aria-selected="false">Address</a>
+                        <a class="nav-link" id="v-pills-messages-tab" data-toggle="pill" href="#v-pills-messages" role="tab" aria-controls="v-pills-messages" aria-selected="false">Contacts</a>
+                        <a class="nav-link" id="v-pills-agreement-tab" data-toggle="pill" href="#v-pills-agreement" role="tab" aria-controls="v-pills-agreement" aria-selected="false">Master Agreement</a>
+                        <a class="nav-link" id="v-pills-handbook-tab" data-toggle="pill" href="#v-pills-handbook" role="tab" aria-controls="v-pills-handbook" aria-selected="false">Handbook</a>
+                    </div>
+                </div>
+                <div class="col-12 col-lg-9">
+                    <div class="tab-content" id="v-pills-tabContent">
+                        <div class="tab-pane fade show active" id="v-pills-home" role="tabpanel" aria-labelledby="v-pills-home-tab">
+                            <p style="text-align: left;"><strong>Mission Statement</strong></p>
+<p style="text-align: left;"><span id="docs-internal-guid-90c188d6-7fff-2ad4-c58c-6093fe306017"><span>The Rocky Mountain Percussion Association commits to providing a competitive performance outlet supporting music education in the rocky mountain region; enriching the lives of young performers through an inclusive and supportive environment where young performers develop their skills, confidence, and passion.</span></span></p>
+<p style="text-align: left;"><strong>Our Story</strong></p>
+<p style="text-align: left;"><strong></strong>The Rocky Mountain Percussion Association is a 501(c)3 not-for-profit Colorado based youth organization, that was started in 1991 by a group of percussion instructors, judges and educators who were concerned about the level of percussion training and performance, primarily at the high school level. Steve Yates, Joe Bartko and Ralph Hardimon were the founders of the RMPA and along with Charles Craig formed what is now one of the nation&rsquo;s premier percussion organizations of its kind. Our main focus is student motivation, educational training, and achievement through the percussion activity.</p>
+<p style="text-align: left;">The association is the governing body of the indoor percussion activity in the Rocky Mountain region and sponsors a series of indoor percussion events, educational clinics and competitions during the winter and spring months.</p>
+<p style="text-align: left;">These programs provide a motivational tool that can help turn non-percussionists and a typical drum section into a cohesive and entertaining percussion ensemble. The nation&rsquo;s top percussion judges adjudicate all of our competitions.</p>
+<p style="text-align: left;">Since the first event was held in 1993, the RMPA has provided competition and training for over 15,000 students, and has become one of the premier percussion organizations of its kind in the country and serves as a national model by which other organizations are administered and managed.</p>
+<p style="text-align: left;"><strong>Winter Percussion</strong></p>
+<p style="text-align: left;">The Winter Percussion Activity was organized to provide a program for the many percussion students participating in a typical marching band during the fall season, but not having a comparable performance outlet during the winter and spring seasons. The traditional jazz band, concert band, wind ensemble, etc. does not involve the larger number of percussion students that a marching band requires.</p>
+<p style="text-align: left;">The first units participating in the percussion activity were primarily from scholastic marching units, utilizing both a battery and pit ensemble in a setting that limited the amount of marching and showmanship. Within a few short years, the number of independent organizations participating in the competitions increased, and the performance venue was enlarged to allow for more development of the visual and theatrical potential of the activity. Soon thereafter, traditional &ldquo;concert&rdquo; percussion ensembles were included as an additional performance outlet for student percussionists preferring that genre.</p>
+<p style="text-align: left;"><span>The Rocky Mountain Percussion Association operates under the rules and guidelines of Winter Guard International.</span></p>                        </div>
+                        <div class="tab-pane fade" id="v-pills-profile" role="tabpanel" aria-labelledby="v-pills-profile-tab">
+                            <p>PO Box 184</p>
+<p>Broomfield, CO 80038</p>                        </div>
+                        <div class="tab-pane fade" id="v-pills-messages" role="tabpanel" aria-labelledby="v-pills-messages-tab">
+                            <p><strong>2025-2026 Board of Directors</strong></p>
+<ul>
+<li>President -&nbsp;Colin Spear ~ <a href="mailto:colin@rmpa.org">colin@rmpa.org</a></li>
+<li>Vice President - Scott Wilson ~ <a href="mailto:scott@rmpa.org">scott@rmpa.org</a></li>
+<li>Treasurer - Lori Nonies ~&nbsp;<a href="mailto:lori@rmpa.org">lori@rmpa.org</a></li>
+<li>Secretary -&nbsp;Lynn Collins ~&nbsp;<a href="mailto:lynn@rmpa.org">lynn@rmpa.org</a></li>
+<li>Marketing Director - Dylan Kroha ~ <a href="mailto:dylan@rmpa.org">dylan@rmpa.org</a></li>
+<li>Director of Education and Development - Tanner Homa ~ <a href="mailto:tanner@rmpa.org">tanner@rmpa.org</a></li>
+<li>Director of Education and Development - Julian Davidson ~&nbsp;<a href="mailto:julian@rmpa.org">julian@rmpa.org</a></li>
+</ul>
+<p><strong>2025-2026 Support Team</strong></p>
+<ul>
+<li>Financial Secretary - Erin Moore ~&nbsp;<a href="mailto:erin@affinity.cpa">erin@affinity.cpa</a></li>
+</ul>
+<p><strong>Founding Members&nbsp;<small>(circa 1991)</small></strong></p>
+<ul>
+<li>Steve Yates</li>
+<li>Ralph Hardimon</li>
+<li>Joe Bartko</li>
+<li>Charles Craig</li>
+</ul>
+<ul>
+</ul>                        </div>
+                        <div class="tab-pane fade" id="v-pills-agreement" role="tabpanel" aria-labelledby="v-pills-agreement-tab">
+                            <p>Coming Soon...</p>                        </div>
+                        <div class="tab-pane fade" id="v-pills-handbook" role="tabpanel" aria-labelledby="v-pills-handbook-tab">
+                            <p><a href="https://docs.google.com/document/d/e/2PACX-1vS3IJA3VlrkGYLvh_FLqyCmkVGR-b-Jr4d4UXcjLtVPXp6ZTb3rOSSy88eZHtpRA-E7BYUQQwTc2lx3/pub"> 2026 RMPA Member Handbook&nbsp;</a>This document will be a must-read for all directors, instructors, and performers.</p>                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+ 
+        <!-- Newsletter Signup Form -->
+        <div class="newsletter_form hide-on-load">
+            <h1>Newsletter Signup</h1>
+
+            <div class="hide-on-load">
+                <input type="text" name="username" />
+                <input type="password" name="password" />
+            </div>
+
+            <div class="newsletter-submission-status"></div>
+
+            <div class="newsletter-submission-frame">
+                <div class="form-group">
+                    <div class="row">
+                        <div class="col-4"><label>Name</label></div>
+                        <div class="col-8"><input type="text" name="name" value="" placeholder="Name" class="form-control newsletter-name" /></div>
+                    </div>
+                </div>
+
+                <div class="form-group">
+                    <div class="row">
+                        <div class="col-4"><label>Email</label></div>
+                        <div class="col-8"><input type="text" name="email" value="" placeholder="Email" class="form-control newsletter-email" /></div>
+                    </div>
+                </div>
+
+                <div class="form-group">
+                    <div class="row">
+                        <div class="col-4"><label>&nbsp;</label></div>
+                        <div class="col-8"><input type="button" name="submit" value="Submit" class="btn btn-primary newsletter-submit" /></div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Login Form -->
+        <div class="login_form hide-on-load">
+            <h1>Login</h1>
+
+                                <p><small>* Only registered will display in list</small></p>
+
+                    <div class="login_response"></div>
+
+                    <div class="hide-on-load">
+                        <input type="text" name="username" />
+                        <input type="password" name="password" />
+                    </div>
+
+                    <div class="switch-sites-list">
+                        <input type="text" class="form-control typeahead-search" name="ensemble" placeholder="Type Name" />
+                    </div>
+                    <div id="site-list-login" class="hide-on-load">Alameda International HS,Arapahoe High School,Arvada High School,Bear Creek High School Percussion Ensemble,Black Diamond Percussion ,Blue Knights Percussion Ensemble,Blue Knights Winds,Broomfield High School,Burlington Cougar Drumline,Ca&ntilde;on City Tiger Pride Winter Percussion,Castle View in Douglas County,Centaurus Winter Percussion Ensemble,Chaparral High School Winter Percussion Ensemble,Columbine High School,Columbine High School,D'Evelyn Percussion Ensemble,D49indoor,Dakota Ridge High School,Dakota Ridge High School,Denver South Rebels,District 49 Winter Percussion,Doherty High School Percussion Ensemble,Douglas County High School Winter Percussion,Eaglecrest High School,Eaglecrest High School,Englewood High School Percussion Ensemble,Evergreen High School Winter Percussion,Fairivew High School ,Fossil Ridge Winter Percussion,Fountain-Fort Carson High School Percussion Ensemble,Gateway High School Percussion Ensemble,Great Oak High School,Harrison District 2 Percussion Ensemble,Heritage High School Winter Percussion,Highlands Ranch Falcon Percussion,Joeâ€™s test to help Burlington ,Lakewood Winter Percussion Ensemble,Legacy High School Winter Percussion,Legend Titan Percussion Ensemble,Longmont Winter Percussion,Loveland Indoor Percussion,Mesa Ridge Percussion Ensemble,Monarch Indoor Percussion,Mountain Range High School,Mountain Vista Percussion Ensemble,Pine Creek High School,Pomona High School Winds,Ponderosa High School,Prairie View High School,Pueblo Central High School ,Pueblo Central High School,Pueblo City Schools Indoor Percussion,Rampart High School,Rangeview High School,Rise Percussion,Rise Percussion Concert,Rise2,Rise2 Concert,Rock Canyon High School,Standley Lake High School,Test,Test,ThunderRidge High School,West High School Drumline,West High School Drumline,Wheat Ridge HS Winter Percussion,William J. Palmer High School,Windsor Percussion Ensemble </div>
+
+                    <br />
+                    <div class="hide-on-load">
+                        <input type="text" name="username" />
+                        <input type="password" name="password" />
+                    </div>
+                    <input type="password" value="" class="form-control password" placeholder="Password" />
+                    <br />
+                    
+                    <input type="submit" class="btn btn-primary login_now" value="Login" /> 
+                    
+                    <div class="clearfix"></div>
+                    <br />
+
+                    <p><a href="//rmpa.org/ensemble/forgot">Forgot Password</a><!--  | <a href="#" class="toggle_type"><span class="login_type">Judge</span> Login</a> --></p>
+
+                            </div>
+
+        <script src="//ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
+        <script>window.jQuery || document.write('<script src="//rmpa.org/theme/main/assets/js/vendor/jquery-3.3.1.min.js"><\/script>')</script>
+        <script>
+            var site_url = "//rmpa.org";
+        </script>
+        <script src="//rmpa.org/theme/main/assets/js/vendor/bootstrap.min.js?v=2"></script>
+        <script src="//rmpa.org/theme/main/assets/js/typeahead.js"></script>
+        <script src="//rmpa.org/theme/main/assets/js/main.js?v=11"></script>
+
+                            <script type="text/javascript" src="/views/competitions/competitions.js?v=2152020_11_14"></script>
+                        </body>
+</html>

--- a/data/test-fixtures/rmpa-scores-page.html
+++ b/data/test-fixtures/rmpa-scores-page.html
@@ -1,0 +1,1450 @@
+<!doctype html>
+<!--[if lt IE 7]>      <html class="no-js lt-ie9 lt-ie8 lt-ie7" lang=""> <![endif]-->
+<!--[if IE 7]>         <html class="no-js lt-ie9 lt-ie8" lang=""> <![endif]-->
+<!--[if IE 8]>         <html class="no-js lt-ie9" lang=""> <![endif]-->
+<!--[if gt IE 8]><!--> <html class="no-js" lang=""> <!--<![endif]-->
+    <head>
+        <meta charset="utf-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+        <title>RMPA</title>
+        <meta name="description" content="">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <!-- <link rel="apple-touch-icon" href="//rmpa.org/apple-touch-icon.png"> -->
+        <link rel="shortcut icon" type="image/x-icon" href="/favicon.png" />
+
+        <!-- link href='https://fonts.googleapis.com/css?family=Oswald:400,300' rel='stylesheet' type='text/css' -->
+        <!-- <link rel="stylesheet" href="//rmpa.org/theme/main/assets/fonts/stylesheet.css"> -->
+        <link href="https://fonts.googleapis.com/css?family=Oswald:200|Raleway:400,800&display=swap" rel="stylesheet">
+        <link rel="stylesheet" href="//rmpa.org/theme/main/assets/css/bootstrap.min.css?v=2">
+        <link rel="stylesheet" href="//rmpa.org/theme/main/assets/css/main.css?v=241">
+        <link rel="stylesheet" href="//rmpa.org/theme/main/assets/css/print.css?v=206" media="print">
+
+        <!--[if lt IE 9]>
+            <script src="js/vendor/html5-3.6-respond-1.4.2.min.js"></script>
+        <![endif]-->
+
+        <!-- <script src="https://kit.fontawesome.com/36bf5b8bef.js"></script> -->
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css">
+    </head>
+    <body class="home">
+        <!--[if lt IE 8]>
+            <p class="browserupgrade">You are using an <strong>outdated</strong> browser. Please <a href="http://browsehappy.com/">upgrade your browser</a> to improve your experience.</p>
+        <![endif]-->
+
+
+        <header>
+            <nav class="navbar navbar-dark fixed-top">
+                <a class="navbar-brand" href="/"><img src="/theme/main/assets/images/rmpa_logo_header.png" class="mw-100" /></a>
+                
+                <div class="float-right text-right">
+                    <!-- <a class="newsletter-signup text-white" href="#" style="text-decoration: none; font-size: 20px; display: inline-block; padding: 15px 5px;">Newsletter</a> -->
+                    <a class="ensemble-search text-white" href="#" style="font-size: 20px; display: inline-block; padding: 0 0 0 10px;">
+                        <i class="bi bi-search"></i>    
+                        <!-- <i class="fas fa-search"></i> -->
+                    </a>
+                    <a class="ensemble-login text-white" href="#" style="font-size: 20px; display: inline-block; padding: 0 0 0 10px;">
+                        <i class="bi bi-person"></i>    
+                        <!-- <i class="fas fa-user-circle"></i> -->
+                    </a>
+                    <a class="show-nav-modal text-white" href="#" style="font-size: 20px; display: inline-block; padding: 0 0 0 10px;">
+                        <i class="bi bi-list"></i>    
+                        <!-- <i class="fas fa-bars"></i> -->
+                    </a>
+                </div>
+            </nav>
+
+            <div class="collapse" id="navigation">
+                <div class="text-center">
+                    <h2><a href="/about/our-story" class="load-about">About</a></h2>
+                    <h2><a href="/news">News</a></h2>
+                    <h2><a href="/calendar">Calendar</a></h2>
+                    <h2><a href="/scores">Scores</a></h2>
+                    <h2><a href="/competitions">Competitions</a></h2>
+                    <h2><a href="/education">Education</a></h2>
+                    <h2><a target="_blank" href="https://rmpamarketplace.square.site">Donate</a></h2>
+                    <!-- <h2><a href="https://www.coloradogives.org/index.php?section=organizations&action=newDonation&fwID=39858" target="_blank">Donate</a></h2> -->
+                    <h2><a href="/register">Registration</a></h2>
+                    <!-- <h2><a href="/about/virtualsolocompetition">Virtual Solo Competition</a></h2> -->
+                </div>
+            </div>
+        </header>
+
+        <main role="main">
+
+            
+
+<div class="container">
+    <div class="main-top-pad">
+        <h1 class="big-block">Scores</h1>
+
+        <div class="row justify-content-md-center">
+            <div class="col col-md-6 mx-auto">
+                
+                    <ul class="list-group mb-4">
+                        <li class="list-group-item active">
+                            2025                        </li>
+                        
+                        
+                            <li class="list-group-item">
+                                <a href="http://recaps.competitionsuite.com/a68d3f2d-84ed-402d-9cae-350893814007.htm" target="_blank">
+                                    March, 29 2025                                </a> 
+                                RMPA State Championships                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="http://recaps.competitionsuite.com/d133475d-3603-4824-90cf-ebd9d12b71ae.htm" target="_blank">
+                                    March, 28 2025                                </a> 
+                                RMPA State Championships                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="http://recaps.competitionsuite.com/7236f45e-50c0-4d25-b38c-0864cf7f2b60.htm" target="_blank">
+                                    March, 22 2025                                </a> 
+                                Regular Season Show #6                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="http://recaps.competitionsuite.com/e30e1c36-b15c-4903-bcd8-c2de6d632423.htm" target="_blank">
+                                    March, 8 2025                                </a> 
+                                Regular Season Show #5                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="http://recaps.competitionsuite.com/600b63ab-1baa-4212-9d58-3963b8f6dcf0.htm" target="_blank">
+                                    March, 1 2025                                </a> 
+                                Regular Season Show #4                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="http://recaps.competitionsuite.com/d60076f9-b040-4939-a6d8-effac56808a5.htm" target="_blank">
+                                    February, 22 2025                                </a> 
+                                Regular Season Show #3                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="http://recaps.competitionsuite.com/f2d43f64-dc59-42bd-be62-936124088a0e.htm" target="_blank">
+                                    February, 15 2025                                </a> 
+                                Regular Season Show #2                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="http://recaps.competitionsuite.com/08ab8a45-950b-4d9e-8c47-b7e6543dd910.htm" target="_blank">
+                                    February, 8 2025                                </a> 
+                                Regular Season Show #1                            </li>
+
+                                            </ul>
+
+                
+                    <ul class="list-group mb-4">
+                        <li class="list-group-item active">
+                            2024                        </li>
+                        
+                        
+                            <li class="list-group-item">
+                                <a href="http://recaps.competitionsuite.com/34c9e408-c3c6-4ac3-be77-64ac6718d42d.htm" target="_blank">
+                                    April, 13 2024                                </a> 
+                                RMPA Championships                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="http://recaps.competitionsuite.com/a6948a7c-5adf-44f1-9e92-b1a6317f5e30.htm" target="_blank">
+                                    March, 30 2024                                </a> 
+                                RMPA Championships                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="http://recaps.competitionsuite.com/0d873901-b81a-46f3-9f24-de0a5ea21276.htm" target="_blank">
+                                    March, 23 2024                                </a> 
+                                RMPA Show #5                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="http://recaps.competitionsuite.com/25cc65b3-77fd-4996-8ca1-6b4946838b3d.htm" target="_blank">
+                                    March, 16 2024                                </a> 
+                                RMPA Show #4                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="http://recaps.competitionsuite.com/c74c2be6-9475-4d2d-955b-8c8af19d6996.htm" target="_blank">
+                                    March, 2 2024                                </a> 
+                                RMPA Show #3                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="http://recaps.competitionsuite.com/24b46b7f-8bea-4a21-8278-c98a55528bc9.htm" target="_blank">
+                                    February, 17 2024                                </a> 
+                                RMPA Show #2                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="http://recaps.competitionsuite.com/878938c3-93b9-471a-a5f3-e043cac94858.htm" target="_blank">
+                                    February, 10 2024                                </a> 
+                                RMPA Show #1                            </li>
+
+                                            </ul>
+
+                
+                    <ul class="list-group mb-4">
+                        <li class="list-group-item active">
+                            2023                        </li>
+                        
+                        
+                            <li class="list-group-item">
+                                <a href="http://recaps.competitionsuite.com/343cce5c-1782-491f-b49e-e41a642c1fc9.htm" target="_blank">
+                                    April, 15 2023                                </a> 
+                                RMPA Championships                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="http://recaps.competitionsuite.com/40c709a1-3cfa-44a8-9601-d3dd0be7da45.htm" target="_blank">
+                                    April, 8 2023                                </a> 
+                                RMPA Championships                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="http://recaps.competitionsuite.com/1f63d4e3-b95d-43d0-b764-92a5600499f3.htm" target="_blank">
+                                    April, 1 2023                                </a> 
+                                RMPA Show #4                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="http://recaps.competitionsuite.com/e65eaebe-675b-4bac-bc20-0d5a2d0ec237.htm" target="_blank">
+                                    March, 18 2023                                </a> 
+                                RMPA Show #3                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="http://recaps.competitionsuite.com/6fbb2ffd-4f6b-4bc3-90de-55d41c07b0bb.htm" target="_blank">
+                                    March, 17 2023                                </a> 
+                                VIRTUAL - RMPA Show #3                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="http://recaps.competitionsuite.com/67ba1398-4af0-4f98-b60c-bf52285d5576.htm" target="_blank">
+                                    March, 4 2023                                </a> 
+                                RMPA Show #2                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="http://recaps.competitionsuite.com/c6c0c858-53ba-49eb-bfc2-308950c529c8.htm" target="_blank">
+                                    February, 18 2023                                </a> 
+                                RMPA Show #1                            </li>
+
+                                            </ul>
+
+                
+                    <ul class="list-group mb-4">
+                        <li class="list-group-item active">
+                            2022                        </li>
+                        
+                        
+                            <li class="list-group-item">
+                                <a href="http://recaps.competitionsuite.com/c7a4094b-a0ad-40cd-a0a8-dfdd3403b541.htm" target="_blank">
+                                    April, 15 2022                                </a> 
+                                RMPA Championship Finals - Virtual                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="http://recaps.competitionsuite.com/ebd58fc9-2ad4-4264-9ade-0e11e2c1d078.htm" target="_blank">
+                                    April, 2 2022                                </a> 
+                                RMPA Championship Prelims - Virtual                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="http://recaps.competitionsuite.com/89d93691-2ef6-43e8-98d0-d9a00fa1f146.htm" target="_blank">
+                                    April, 16 2022                                </a> 
+                                RMPA Championships                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="http://recaps.competitionsuite.com/cd67dcdf-7cda-4353-bcc6-13fed9e3fb99.htm" target="_blank">
+                                    April, 2 2022                                </a> 
+                                RMPA Championships                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="http://recaps.competitionsuite.com/75609e20-662d-4839-804c-caf170b049a1.htm" target="_blank">
+                                    March, 19 2022                                </a> 
+                                RMPA Show #4                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="http://recaps.competitionsuite.com/35e4a570-ebf4-49a2-b72c-4207b6269e7d.htm" target="_blank">
+                                    March, 19 2022                                </a> 
+                                RMPA Show #4 - Virtual                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="http://recaps.competitionsuite.com/4eb97d95-4af3-469f-9bdd-9a8bfc5abc55.htm" target="_blank">
+                                    March, 5 2022                                </a> 
+                                RMPA Show #3                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="http://recaps.competitionsuite.com/569132b3-5203-4185-b32b-ee37e8188ce2.htm" target="_blank">
+                                    February, 26 2022                                </a> 
+                                RMPA Show #2                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="http://recaps.competitionsuite.com/371931be-e7c9-42dd-8102-13112110a5d8.htm" target="_blank">
+                                    February, 26 2022                                </a> 
+                                RMPA Show #2 - Virtual                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="http://recaps.competitionsuite.com/dbe5ca5a-bf1f-4fa3-819f-ee4dcf519159.htm" target="_blank">
+                                    February, 19 2022                                </a> 
+                                RMPA Show #1                            </li>
+
+                                            </ul>
+
+                
+                    <ul class="list-group mb-4">
+                        <li class="list-group-item active">
+                            2021                        </li>
+                        
+                        
+                            <li class="list-group-item">
+                                <a href="http://recaps.competitionsuite.com/d76a01a7-ba7b-4827-98d9-325680bc1041.htm" target="_blank">
+                                    April, 9 2021                                </a> 
+                                RMPA Championships                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="http://recaps.competitionsuite.com/767ebeb1-1678-4155-bded-d419d775ef2a.htm" target="_blank">
+                                    April, 2 2021                                </a> 
+                                RMPA Championships                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="http://recaps.competitionsuite.com/7d5ee884-821e-403f-8d95-7e1c533066e2.htm" target="_blank">
+                                    March, 21 2021                                </a> 
+                                RMPA Regular Season Show #3                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="http://recaps.competitionsuite.com/aa8e0151-e534-4f84-a4e5-ea81c6ecd182.htm" target="_blank">
+                                    March, 13 2021                                </a> 
+                                RMPA Regular Season Show #2                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="http://recaps.competitionsuite.com/1f37bd15-3c5f-405d-bd54-f63942d58b93.htm" target="_blank">
+                                    March, 5 2021                                </a> 
+                                RMPA Regular Season Show #1                            </li>
+
+                                            </ul>
+
+                
+                    <ul class="list-group mb-4">
+                        <li class="list-group-item active">
+                            2020                        </li>
+                        
+                        
+                            <li class="list-group-item">
+                                <a href="http://recaps.competitionsuite.com/b4316bc5-9bda-48e8-939b-e4eae3b1c220.htm" target="_blank">
+                                    February, 29 2020                                </a> 
+                                RMPA contest #3                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="http://recaps.competitionsuite.com/2a9ac683-1dfc-4b9f-9a3d-598f81c341c1.htm" target="_blank">
+                                    February, 22 2020                                </a> 
+                                RMPA Contest #2                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="http://recaps.competitionsuite.com/751b9443-990f-472c-8d05-5ed934d46242.htm" target="_blank">
+                                    February, 15 2020                                </a> 
+                                RMPA Contest #1                            </li>
+
+                                            </ul>
+
+                
+                    <ul class="list-group mb-4">
+                        <li class="list-group-item active">
+                            2019                        </li>
+                        
+                        
+                            <li class="list-group-item">
+                                <a href="http://recaps.competitionsuite.com/7e55b284-4d4b-4f2d-a4d3-5c488f13c643.htm" target="_blank">
+                                    April, 6 2019                                </a> 
+                                RMPA State Championships                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="http://recaps.competitionsuite.com/b2c6a79e-90b8-4153-80b0-b32f3f876049.htm" target="_blank">
+                                    April, 6 2019                                </a> 
+                                RMPA State Championships                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="http://recaps.competitionsuite.com/1422aa96-7f43-4e34-9107-ff4ad64d4f1d.htm" target="_blank">
+                                    March, 23 2019                                </a> 
+                                RMPA Contest #5                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="http://recaps.competitionsuite.com/6c3652d6-91f7-4d26-a74d-bd3bb51c1c95.htm" target="_blank">
+                                    March, 16 2019                                </a> 
+                                RMPA Contest #4                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="http://recaps.competitionsuite.com/c1916aed-c799-4acb-911f-0f6e2818a897.htm" target="_blank">
+                                    March, 2 2019                                </a> 
+                                RMPA Contest #3                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="http://recaps.competitionsuite.com/eb271174-5412-4ac8-b5f3-9ac022f32d86.htm" target="_blank">
+                                    February, 23 2019                                </a> 
+                                RMPA Contest #2                            </li>
+
+                                            </ul>
+
+                
+                    <ul class="list-group mb-4">
+                        <li class="list-group-item active">
+                            2018                        </li>
+                        
+                        
+                            <li class="list-group-item">
+                                <a href="http://recaps.competitionsuite.com/fe3e9a26-eebe-48e6-b1cf-cba493ce41f5.htm" target="_blank">
+                                    April, 14 2018                                </a> 
+                                RMPA State Championships                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="http://recaps.competitionsuite.com/7596670c-b31a-4c65-b950-1decd96e24a1.htm" target="_blank">
+                                    April, 14 2018                                </a> 
+                                RMPA State Championships                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="http://recaps.competitionsuite.com/b91a1658-9c60-45ef-b60c-808576c72105.htm" target="_blank">
+                                    March, 31 2018                                </a> 
+                                Contest #5                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="http://recaps.competitionsuite.com/a8c6bf04-6cbc-4c84-a9c1-74aa10ad87c8.htm" target="_blank">
+                                    March, 24 2018                                </a> 
+                                Contest #4                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="http://recaps.competitionsuite.com/d66e8ff2-4fb7-43df-b393-9d7a53d6fe0d.htm" target="_blank">
+                                    March, 10 2018                                </a> 
+                                Contest #3                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="http://recaps.competitionsuite.com/cdf5ca41-e245-428b-8752-fd624450a8be.htm" target="_blank">
+                                    March, 3 2018                                </a> 
+                                Contest #2                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="http://recaps.competitionsuite.com/20e8bf29-50e0-48d8-8306-15e8d54d878f.htm" target="_blank">
+                                    February, 24 2018                                </a> 
+                                Contest #1                            </li>
+
+                                            </ul>
+
+                
+                    <ul class="list-group mb-4">
+                        <li class="list-group-item active">
+                            2017                        </li>
+                        
+                        
+                            <li class="list-group-item">
+                                <a href="http://recaps.competitionsuite.com/ade6fbcc-883b-438b-8fd1-3e6a0ae6c3d7.htm" target="_blank">
+                                    April, 8 2017                                </a> 
+                                RMPA State Championships                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="http://recaps.competitionsuite.com/eff6faec-8b7e-4b20-80e8-440d899887b3.htm" target="_blank">
+                                    April, 8 2017                                </a> 
+                                RMPA State Championships                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="http://recaps.competitionsuite.com/cd51c94e-9790-46eb-ba39-e168004d3664.htm" target="_blank">
+                                    March, 25 2017                                </a> 
+                                RMPA Competition                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="http://recaps.competitionsuite.com/885c0047-8dfe-485e-93e0-567aca476c28.htm" target="_blank">
+                                    March, 11 2017                                </a> 
+                                RMPA Competition                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="http://recaps.competitionsuite.com/6b8f9e4d-be38-4c1e-9e31-f2e21925ef19.htm" target="_blank">
+                                    March, 4 2017                                </a> 
+                                RMPA Competition                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="http://recaps.competitionsuite.com/479cd5fd-9805-4e13-abe8-50dd5fe97b89.htm" target="_blank">
+                                    February, 25 2017                                </a> 
+                                RMPA Competition                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="http://recaps.competitionsuite.com/00f37985-0c4f-463f-ba22-a17cac39660f.htm" target="_blank">
+                                    February, 18 2017                                </a> 
+                                RMPA Competition                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="http://recaps.competitionsuite.com/48399833-a002-48db-8e4f-9be5c74c8cd7.htm" target="_blank">
+                                    February, 18 2017                                </a> 
+                                RMPA Competition                            </li>
+
+                                            </ul>
+
+                
+                    <ul class="list-group mb-4">
+                        <li class="list-group-item active">
+                            2016                        </li>
+                        
+                        
+                            <li class="list-group-item">
+                                <a href="http://recaps.competitionsuite.com/4b21b5c0-7835-426c-ab8f-76714de7dc68.htm" target="_blank">
+                                    April, 9 2016                                </a> 
+                                RMPA Championships                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="http://recaps.competitionsuite.com/ae6a8735-3a14-4b09-8b94-8606a04c4ff1.htm" target="_blank">
+                                    April, 9 2016                                </a> 
+                                RMPA Championships                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="http://recaps.competitionsuite.com/90324804-ce18-442e-b789-b3f0e06ef00d.htm" target="_blank">
+                                    March, 26 2016                                </a> 
+                                RMPA Competition                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="http://recaps.competitionsuite.com/73a74fda-4387-4291-afc8-fa08be4e30a1.htm" target="_blank">
+                                    March, 19 2016                                </a> 
+                                RMPA Competition                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="http://recaps.competitionsuite.com/7d34f9c4-c270-442c-a5ad-75a9ea3f4946.htm" target="_blank">
+                                    March, 12 2016                                </a> 
+                                RMPA Competition                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="http://recaps.competitionsuite.com/f446e0b6-b6a1-4a59-a403-4c4bad54e220.htm" target="_blank">
+                                    February, 27 2016                                </a> 
+                                RMPA Competition                            </li>
+
+                                            </ul>
+
+                
+                    <ul class="list-group mb-4">
+                        <li class="list-group-item active">
+                            2015                        </li>
+                        
+                        
+                            <li class="list-group-item">
+                                <a href="http://recaps.competitionsuite.com/02aac19f-289b-43ca-ab25-eca07fab0ea1.htm" target="_blank">
+                                    April, 4 2015                                </a> 
+                                RMPA Championships                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="http://recaps.competitionsuite.com/8959d618-16e7-42f0-a233-58527f080dfe.htm" target="_blank">
+                                    April, 4 2015                                </a> 
+                                RMPA Championships                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="http://recaps.competitionsuite.com/841e6cf3-73c2-4e37-a3db-8959e9589fad.htm" target="_blank">
+                                    April, 4 2015                                </a> 
+                                RMPA Championships                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="http://recaps.competitionsuite.com/a8fb4dfd-69cb-4d12-8c33-7f387e0c7029.htm" target="_blank">
+                                    April, 4 2015                                </a> 
+                                RMPA Championships                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="http://recaps.competitionsuite.com/66bbd5d2-7373-42eb-87dc-b978bad312fe.htm" target="_blank">
+                                    March, 28 2015                                </a> 
+                                RMPA Contest Percussion                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="http://recaps.competitionsuite.com/8814c8bd-999a-47d5-b46a-00506a1f5bb0.htm" target="_blank">
+                                    March, 28 2015                                </a> 
+                                RMPA Contest Winds                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="http://recaps.competitionsuite.com/41777f82-7d34-4b29-9937-efbc747cacaa.htm" target="_blank">
+                                    March, 21 2015                                </a> 
+                                RMPA Competition Percussion                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="http://recaps.competitionsuite.com/ea211b36-4f76-4995-9351-b246e5c6f85e.htm" target="_blank">
+                                    March, 21 2015                                </a> 
+                                RMPA Contest Winds                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="http://recaps.competitionsuite.com/7ed0129d-20b5-4a6f-945c-72930f3cf5c1.htm" target="_blank">
+                                    March, 14 2015                                </a> 
+                                RMPA Contest Percussion                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="http://recaps.competitionsuite.com/8f7c47d6-36ab-4e6b-82b2-9b73991e4faa.htm" target="_blank">
+                                    March, 14 2015                                </a> 
+                                RMPA Contest Winds                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="http://recaps.competitionsuite.com/823ccfa6-fdbb-462f-8bd7-2f39ffb0aff7.htm" target="_blank">
+                                    February, 28 2015                                </a> 
+                                RMPA Competition                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="http://recaps.competitionsuite.com/70a38557-a24d-4ece-a033-2e4236622599.htm" target="_blank">
+                                    February, 28 2015                                </a> 
+                                RMPA Winds Competition                            </li>
+
+                                            </ul>
+
+                
+                    <ul class="list-group mb-4">
+                        <li class="list-group-item active">
+                            2014                        </li>
+                        
+                        
+                            <li class="list-group-item">
+                                <a href="http://recaps.competitionsuite.com/f41f27ec-c340-4927-91ee-2b8a2251a1cc.htm" target="_blank">
+                                    March, 29 2014                                </a> 
+                                RMPA Championships                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="http://recaps.competitionsuite.com/6c7be20c-d269-462a-8a14-8af7c8280300.htm" target="_blank">
+                                    March, 29 2014                                </a> 
+                                RMPA Championships                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="http://recaps.competitionsuite.com/ee46d6c0-df62-4d2d-8c0c-c4d9cfb1067b.htm" target="_blank">
+                                    March, 22 2014                                </a> 
+                                RMPA Contest                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="http://recaps.competitionsuite.com/6fb57457-8af5-4b09-b534-411d3ee1a856.htm" target="_blank">
+                                    March, 8 2014                                </a> 
+                                RMPA Contest                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="http://recaps.competitionsuite.com/f244b787-c550-49d7-99dd-80e6d60e7da8.htm" target="_blank">
+                                    March, 1 2014                                </a> 
+                                RMPA Contest                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="http://recaps.competitionsuite.com/7e514130-e1d7-4689-8fe4-201d6019573b.htm" target="_blank">
+                                    February, 22 2014                                </a> 
+                                RMPA Contest                            </li>
+
+                                            </ul>
+
+                
+                    <ul class="list-group mb-4">
+                        <li class="list-group-item active">
+                            2013                        </li>
+                        
+                        
+                            <li class="list-group-item">
+                                <a href="http://recaps.competitionsuite.com/1515e846-9845-4d5a-84fe-41fc739188e3.htm" target="_blank">
+                                    April, 13 2013                                </a> 
+                                RMPA Championships                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="http://recaps.competitionsuite.com/066e6bc4-764f-4171-8615-99d979650a40.htm" target="_blank">
+                                    April, 13 2013                                </a> 
+                                RMPA Championships                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="http://recaps.competitionsuite.com/4307d5d4-b1fc-4dab-89be-8363d7e02efe.htm" target="_blank">
+                                    April, 6 2013                                </a> 
+                                RMPA Contest - Longmont H.S.                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="http://recaps.competitionsuite.com/bd347c5f-60ee-40b3-b316-b43bd96a89c0.htm" target="_blank">
+                                    March, 30 2013                                </a> 
+                                RMPA Contest - Mountain Range H.S.                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="http://recaps.competitionsuite.com/1466b464-5db4-4009-af30-30ffe629aad9.htm" target="_blank">
+                                    March, 16 2013                                </a> 
+                                RMPA Contest - Northglenn H.S.                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="http://recaps.competitionsuite.com/11365429-ffa3-40a8-a6e5-e9650bdc4dff.htm" target="_blank">
+                                    March, 2 2013                                </a> 
+                                RMPA Contest - Wheat Ridge H.S.                            </li>
+
+                                            </ul>
+
+                
+                    <ul class="list-group mb-4">
+                        <li class="list-group-item active">
+                            2012                        </li>
+                        
+                        
+                            <li class="list-group-item">
+                                <a href="http://recaps.competitionsuite.com/4f3d490c-4b5c-4c47-938d-8f10a4631d8b.htm" target="_blank">
+                                    March, 3 2012                                </a> 
+                                RMPA Contest - Legacy High School                            </li>
+
+                                            </ul>
+
+                
+                    <ul class="list-group mb-4">
+                        <li class="list-group-item active">
+                            2011                        </li>
+                        
+                        
+                            <li class="list-group-item">
+                                <a href="/admin/system/files/scores_archive/2011_06_April 2nd 2011 - RMPA Championships at 1st Bank Center FINALS.pdf" target="_blank">
+                                     April 2nd 2011                                </a> 
+                                RMPA Championships at 1st Bank Center FINALS                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="/admin/system/files/scores_archive/2011_05_April 2nd 2011 - RMPA Championships at 1st Bank Center PRELIMS.pdf" target="_blank">
+                                     April 2nd 2011                                </a> 
+                                RMPA Championships at 1st Bank Center PRELIMS                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="/admin/system/files/scores_archive/2011_04_March 26th 2011 - Contest #4 at Longmont High School.pdf" target="_blank">
+                                     March 26th 2011                                </a> 
+                                Contest #4 at Longmont High School                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="/admin/system/files/scores_archive/2011_03_March 12th 2011 - Contest #3 at Mountain Range High School.pdf" target="_blank">
+                                     March 12th 2011                                </a> 
+                                Contest #3 at Mountain Range High School                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="/admin/system/files/scores_archive/2011_02_March 5th 2011 - Contest #2 at Legacy High School.pdf" target="_blank">
+                                     March 5th 2011                                </a> 
+                                Contest #2 at Legacy High School                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="/admin/system/files/scores_archive/2011_01_February 26th 2011 - Contest #1 at Adams City High School.pdf" target="_blank">
+                                     February 26th 2011                                </a> 
+                                Contest #1 at Adams City High School                            </li>
+
+                                            </ul>
+
+                
+                    <ul class="list-group mb-4">
+                        <li class="list-group-item active">
+                            2010                        </li>
+                        
+                        
+                            <li class="list-group-item">
+                                <a href="/admin/system/files/scores_archive/2010_07_April 3rd 2010 - RMPA Championships at 1st Bank Center FINALS.pdf" target="_blank">
+                                     April 3rd 2010                                </a> 
+                                RMPA Championships at 1st Bank Center FINALS                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="/admin/system/files/scores_archive/2010_06_April 3rd 2010 - RMPA Championships at 1st Bank Center PRELIMS.pdf" target="_blank">
+                                     April 3rd 2010                                </a> 
+                                RMPA Championships at 1st Bank Center PRELIMS                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="/admin/system/files/scores_archive/2010_05_MARCH 27TH 2010 - Contest #4 at Longmont High School.pdf" target="_blank">
+                                     MARCH 27TH 2010                                </a> 
+                                Contest #4 at Longmont High School                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="/admin/system/files/scores_archive/2010_04_March 13th 2010 - Contest #3 at Mountain Range High School FINALS.pdf" target="_blank">
+                                     March 13th 2010                                </a> 
+                                Contest #3 at Mountain Range High School FINALS                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="/admin/system/files/scores_archive/2010_03_March 13th 2010 - Contest #3 at Mountain Range High School PRELIMS.pdf" target="_blank">
+                                     March 13th 2010                                </a> 
+                                Contest #3 at Mountain Range High School PRELIMS                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="/admin/system/files/scores_archive/2010_02_March 6th 2010 - Contest #2 at Legacy High School.pdf" target="_blank">
+                                     March 6th 2010                                </a> 
+                                Contest #2 at Legacy High School                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="/admin/system/files/scores_archive/2010_01_February 27th 2010 - Contest #1 at Loveland High School.pdf" target="_blank">
+                                     February 27th 2010                                </a> 
+                                Contest #1 at Loveland High School                            </li>
+
+                                            </ul>
+
+                
+                    <ul class="list-group mb-4">
+                        <li class="list-group-item active">
+                            2009                        </li>
+                        
+                        
+                            <li class="list-group-item">
+                                <a href="/admin/system/files/scores_archive/2009_07_April 11th 2009 - RMPA Championships at Legend High School FINALS.pdf" target="_blank">
+                                     April 11th 2009                                </a> 
+                                RMPA Championships at Legend High School FINALS                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="/admin/system/files/scores_archive/2009_06_April 11th 2009 - RMPA Championships at Legend High School PRELIMS.pdf" target="_blank">
+                                     April 11th 2009                                </a> 
+                                RMPA Championships at Legend High School PRELIMS                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="/admin/system/files/scores_archive/2009_05_March 14th 2009 - Contest #3 - Longmont High School.pdf" target="_blank">
+                                     March 14th 2009                                </a> 
+                                Contest #3                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="/admin/system/files/scores_archive/2009_04_March 9th 2009 - Contest #2 at Mountain Range High School.pdf" target="_blank">
+                                     March 9th 2009                                </a> 
+                                Contest #2 at Mountain Range High School                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="/admin/system/files/scores_archive/2009_02_February 28 2009 - Contest #1 at Legacy High School FINALS.pdf" target="_blank">
+                                     February 28 2009                                </a> 
+                                Contest #1 at Legacy High School FINALS                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="/admin/system/files/scores_archive/2009_01_February 28 2009 - Contest #1 at Legacy High School PRELIMS.pdf" target="_blank">
+                                     February 28 2009                                </a> 
+                                Contest #1 at Legacy High School PRELIMS                            </li>
+
+                                            </ul>
+
+                
+                    <ul class="list-group mb-4">
+                        <li class="list-group-item active">
+                            2008                        </li>
+                        
+                        
+                            <li class="list-group-item">
+                                <a href="/admin/system/files/scores_archive/2008_09_April 12th 2008 - RMPA Championships at Budweiser Events center FINALS.pdf" target="_blank">
+                                     April 12th 2008                                </a> 
+                                RMPA Championships at Budweiser Events center FINALS                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="/admin/system/files/scores_archive/2008_08_April 12th 2008 - RMPA Championships at Budweiser Events center PRELIMS.pdf" target="_blank">
+                                     April 12th 2008                                </a> 
+                                RMPA Championships at Budweiser Events center PRELIMS                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="/admin/system/files/scores_archive/2008_07_April 5th 2008 Contest #5 at Northglenn High School FINALS.pdf" target="_blank">
+                                     April 5th 2008 Contest #5 at Northglenn High School FINALS                                </a> 
+                                                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="/admin/system/files/scores_archive/2008_06_April 5th 2008 Contest #5 at Northglenn High School PRELIMS.pdf" target="_blank">
+                                     April 5th 2008 Contest #5 at Northglenn High School PRELIMS                                </a> 
+                                                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="/admin/system/files/scores_archive/2008_05_March 29th 2008 - Contest #4 at Longmont High School.pdf" target="_blank">
+                                     March 29th 2008                                </a> 
+                                Contest #4 at Longmont High School                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="/admin/system/files/scores_archive/2008_04_March 22nd 2008 - WGI Regional at Northglenn High School FINALS.pdf" target="_blank">
+                                     March 22nd 2008                                </a> 
+                                WGI Regional at Northglenn High School FINALS                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="/admin/system/files/scores_archive/2008_03_March 22nd 2008 - WGI Regional at Northglenn High School PRELIMS.pdf" target="_blank">
+                                     March 22nd 2008                                </a> 
+                                WGI Regional at Northglenn High School PRELIMS                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="/admin/system/files/scores_archive/2008_02_March 15th 2008 - Contest #3 at Legacy High School FINALS.pdf" target="_blank">
+                                     March 15th 2008                                </a> 
+                                Contest #3 at Legacy High School FINALS                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="/admin/system/files/scores_archive/2008_01_March 15th 2008 - Contest #3 at Legacy High School PRELIMS.pdf" target="_blank">
+                                     March 15th 2008                                </a> 
+                                Contest #3 at Legacy High School PRELIMS                            </li>
+
+                                            </ul>
+
+                
+                    <ul class="list-group mb-4">
+                        <li class="list-group-item active">
+                            2007                        </li>
+                        
+                        
+                            <li class="list-group-item">
+                                <a href="/admin/system/files/scores_archive/2007_07_April 7th 2007 - RMPA Championships - Budweiser Events Center FINALS.pdf" target="_blank">
+                                     April 7th 2007                                </a> 
+                                RMPA Championships                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="/admin/system/files/scores_archive/2007_06_April 7th 2007 - RMPA Championships - Budweiser Events Center PRELIMS.pdf" target="_blank">
+                                     April 7th 2007                                </a> 
+                                RMPA Championships                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="/admin/system/files/scores_archive/2007_04_March 24th 2007 - Contest #4 at Northglenn High School.pdf" target="_blank">
+                                     March 24th 2007                                </a> 
+                                Contest #4 at Northglenn High School                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="/admin/system/files/scores_archive/2007_03_March 10th 2007 - Contest #3 - Legacy High School Prelims & Finals.pdf" target="_blank">
+                                     March 10th 2007                                </a> 
+                                Contest #3                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="/admin/system/files/scores_archive/2007_02_March 3rd 2007 - Contest #2 at Heritage High School.pdf" target="_blank">
+                                     March 3rd 2007                                </a> 
+                                Contest #2 at Heritage High School                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="/admin/system/files/scores_archive/2007_01_February 24th 2007 - Contest #1 at Sheridan High School.pdf" target="_blank">
+                                     February 24th 2007                                </a> 
+                                Contest #1 at Sheridan High School                            </li>
+
+                                            </ul>
+
+                
+                    <ul class="list-group mb-4">
+                        <li class="list-group-item active">
+                            2006                        </li>
+                        
+                        
+                            <li class="list-group-item">
+                                <a href="/admin/system/files/scores_archive/2006_08_April 15th 2006 - RMPA Championships at CU Event Center FINALS.pdf" target="_blank">
+                                     April 15th 2006                                </a> 
+                                RMPA Championships at CU Event Center FINALS                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="/admin/system/files/scores_archive/2006_07_April 15th 2006 - RMPA Championships at CU Event Center PRELIMS.pdf" target="_blank">
+                                     April 15th 2006                                </a> 
+                                RMPA Championships at CU Event Center PRELIMS                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="/admin/system/files/scores_archive/2006_06_April 8th 2006 - Contest #6 at Longmont High School .pdf" target="_blank">
+                                     April 8th 2006                                </a> 
+                                Contest #6 at Longmont High School                             </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="/admin/system/files/scores_archive/2006_05_March 25th 2006 - Contest #5 at Pomona High School.pdf" target="_blank">
+                                     March 25th 2006                                </a> 
+                                Contest #5 at Pomona High School                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="/admin/system/files/scores_archive/2006_04_March 18th 2006 - Contest #4 at Northglenn High School FINALS.pdf" target="_blank">
+                                     March 18th 2006                                </a> 
+                                Contest #4 at Northglenn High School FINALS                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="/admin/system/files/scores_archive/2006_03_March 18th 2006 - Contest #4 at Northglenn High School PRELIMS.pdf" target="_blank">
+                                     March 18th 2006                                </a> 
+                                Contest #4 at Northglenn High School PRELIMS                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="/admin/system/files/scores_archive/2006_02_March 11th 2006 - Contest #3 - Legacy High School.pdf" target="_blank">
+                                     March 11th 2006                                </a> 
+                                Contest #3                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="/admin/system/files/scores_archive/2006_01_February 25th 2006 - Contest #2 at Mapleton.pdf" target="_blank">
+                                     February 25th 2006                                </a> 
+                                Contest #2 at Mapleton                            </li>
+
+                                            </ul>
+
+                
+                    <ul class="list-group mb-4">
+                        <li class="list-group-item active">
+                            2005                        </li>
+                        
+                        
+                            <li class="list-group-item">
+                                <a href="/admin/system/files/scores_archive/2005_01_April 9th 2005 - RMPA Championships at Denver Coliseum.pdf" target="_blank">
+                                     April 9th 2005                                </a> 
+                                RMPA Championships at Denver Coliseum                            </li>
+
+                                            </ul>
+
+                
+                    <ul class="list-group mb-4">
+                        <li class="list-group-item active">
+                            2004                        </li>
+                        
+                        
+                            <li class="list-group-item">
+                                <a href="/admin/system/files/scores_archive/2004_01_April 9th 2004 - RMPA Championships at Denver Coliseum.pdf" target="_blank">
+                                     April 9th 2004                                </a> 
+                                RMPA Championships at Denver Coliseum                            </li>
+
+                                            </ul>
+
+                
+                    <ul class="list-group mb-4">
+                        <li class="list-group-item active">
+                            2003                        </li>
+                        
+                        
+                            <li class="list-group-item">
+                                <a href="/admin/system/files/scores_archive/2003_01_April 5th 2003 - RMPA Championships at Denver Coliseum.jpeg" target="_blank">
+                                     April 5th 2003                                </a> 
+                                RMPA Championships at Denver Coliseum.jpeg                            </li>
+
+                                            </ul>
+
+                
+                    <ul class="list-group mb-4">
+                        <li class="list-group-item active">
+                            2002                        </li>
+                        
+                        
+                            <li class="list-group-item">
+                                <a href="/admin/system/files/scores_archive/2002_02_April 6th 2002 - RMPA Championships - CU Events Center FINALS.jpeg" target="_blank">
+                                     April 6th 2002                                </a> 
+                                RMPA Championships                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="/admin/system/files/scores_archive/2002_01_April 6th 2002 - RMPA Championships - CU Events Center PRELIMS.jpeg" target="_blank">
+                                     April 6th 2002                                </a> 
+                                RMPA Championships                            </li>
+
+                                            </ul>
+
+                
+                    <ul class="list-group mb-4">
+                        <li class="list-group-item active">
+                            2000                        </li>
+                        
+                        
+                            <li class="list-group-item">
+                                <a href="/admin/system/files/scores_archive/2000_01_RMPA Championships - CU Boulder.pdf" target="_blank">
+                                     RMPA Championships                                </a> 
+                                CU Boulder                            </li>
+
+                                            </ul>
+
+                
+                    <ul class="list-group mb-4">
+                        <li class="list-group-item active">
+                            1999                        </li>
+                        
+                        
+                            <li class="list-group-item">
+                                <a href="/admin/system/files/scores_archive/1999_01_RMPA Championships - CU Boulder.pdf" target="_blank">
+                                     RMPA Championships                                </a> 
+                                CU Boulder                            </li>
+
+                                            </ul>
+
+                
+                    <ul class="list-group mb-4">
+                        <li class="list-group-item active">
+                            1998                        </li>
+                        
+                        
+                            <li class="list-group-item">
+                                <a href="/admin/system/files/scores_archive/1998_04_February 2nd 1998 - Super Show at Pomona High School FINALS.pdf" target="_blank">
+                                     February 2nd 1998                                </a> 
+                                Super Show at Pomona High School FINALS                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="/admin/system/files/scores_archive/1998_03_February 2nd 1998 - Super Show at Pomona High School PRELIMS.pdf" target="_blank">
+                                     February 2nd 1998                                </a> 
+                                Super Show at Pomona High School PRELIMS                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="/admin/system/files/scores_archive/1998_02_April 11th 1998 - RMPA Championships at CU Boulder FINALS.pdf" target="_blank">
+                                     April 11th 1998                                </a> 
+                                RMPA Championships at CU Boulder FINALS                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="/admin/system/files/scores_archive/1998_01_April 11th 1998 - RMPA Championships at CU Boulder PRELIMS.pdf" target="_blank">
+                                     April 11th 1998                                </a> 
+                                RMPA Championships at CU Boulder PRELIMS                            </li>
+
+                                            </ul>
+
+                
+                    <ul class="list-group mb-4">
+                        <li class="list-group-item active">
+                            1997                        </li>
+                        
+                        
+                            <li class="list-group-item">
+                                <a href="/admin/system/files/scores_archive/1997_10_ February 2nd 1997 - WGI Regional at Columbine High School.pdf" target="_blank">
+                                      February 2nd 1997                                </a> 
+                                WGI Regional at Columbine High School                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="/admin/system/files/scores_archive/1997_06_March 15th 1997 - Super Show at Pomona High School FINALS.pdf" target="_blank">
+                                     March 15th 1997                                </a> 
+                                Super Show at Pomona High School FINALS                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="/admin/system/files/scores_archive/1997_02_March 29th 1997 - RMPA Championships at CU Boulder FINALS.pdf" target="_blank">
+                                     March 29th 1997                                </a> 
+                                RMPA Championships at CU Boulder FINALS                            </li>
+
+                                            </ul>
+
+                
+                    <ul class="list-group mb-4">
+                        <li class="list-group-item active">
+                            1996                        </li>
+                        
+                        
+                            <li class="list-group-item">
+                                <a href="/admin/system/files/scores_archive/1996_ April 20th 1996 - RMPA Championships at Overland High School.pdf" target="_blank">
+                                    pril 20th 1996                                </a> 
+                                RMPA Championships at Overland High School                            </li>
+
+                                            </ul>
+
+                
+                    <ul class="list-group mb-4">
+                        <li class="list-group-item active">
+                            1995                        </li>
+                        
+                        
+                            <li class="list-group-item">
+                                <a href="/admin/system/files/scores_archive/1995_03_March 3rd 1995 - WGI Regional at Bear Creek High Sschool.pdf" target="_blank">
+                                     March 3rd 1995                                </a> 
+                                WGI Regional at Bear Creek High Sschool                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="/admin/system/files/scores_archive/1995_02_April 1st 1995 - Contest at Ponoma High School.pdf" target="_blank">
+                                     April 1st 1995                                </a> 
+                                Contest at Ponoma High School                            </li>
+
+                        
+                            <li class="list-group-item">
+                                <a href="/admin/system/files/scores_archive/1995_01_April 15th 1995 - RMPA Championships at Overland High School.pdf" target="_blank">
+                                     April 15th 1995                                </a> 
+                                RMPA Championships at Overland High School                            </li>
+
+                                            </ul>
+
+                
+                    <ul class="list-group mb-4">
+                        <li class="list-group-item active">
+                            1994                        </li>
+                        
+                        
+                            <li class="list-group-item">
+                                <a href="/admin/system/files/scores_archive/1994_01_April 16th 1994 - RMPA Championships at Overland High School.pdf" target="_blank">
+                                     April 16th 1994                                </a> 
+                                RMPA Championships at Overland High School                            </li>
+
+                                            </ul>
+
+                            </div>
+        </div>
+
+    </div>
+</div>
+            <!-- SPONSORS -->
+            <div class="sponsors">
+
+                <div class="container">
+                    <h3 class="text-center text-md-left d-none d-md-block">SPONSORS</h3>
+                    <div class="row no-gutters">
+                    <div class="col"><a href="http://www.risearts.org" target="_blank"><img src="/admin/system/files/pa_primary_white_3000x1200.png" /></a></div><div class="col"><a href="http://springhillsuites.marriott.com" target="_blank"><img src="http://rmpa.org/admin/system/files/springhill.png" /></a></div><div class="col"><a href="https://www.denverpercussion.com/" target="_blank"><img src="/admin/system/files/Denver-Percussion-logo-WHT (2).png" /></a></div><div class="col"><a href="https://ascendperformingarts.org/" target="_blank"><img src="/admin/system/files/Ascend.png" /></a></div><div class="col"><a href="https://www.frolicbrewing.com/" target="_blank"><img src="/admin/system/files/Frolic Logo Male with Lettering.png" /></a></div>                    </div>
+                </div>
+
+            </div>
+
+        </main>
+
+        <!-- FOOTER -->
+        <footer class="container">
+            <div class="row">
+                <div class="col-md-2 text-center text-md-left">
+                    <a href="/" class="d-none d-md-block"><img src="/theme/main/assets/images/rmpa_logo_footer.png" class="mw-100" /></a>
+                </div>
+                <div class="col-md-2">
+                    &nbsp;
+                </div>
+                <div class="col-md-8">
+                    <div class="row">
+                                                <div class="col-md- col">
+                            <p class="">
+                                <strong>Information</strong><br />
+                                <a href="/about/by-laws">By-Laws</a><br />
+<a href="/about/meeting-notes">Meeting Minutes</a><br />
+<a href="mailto:rmpaboard@rmpa.org">Email the Board</a><br />
+<a href="https://docs.google.com/document/d/1F2Rxkw4xZsbHAyuWlE_Y4kBe8NHWqWHh/edit?usp=sharing&ouid=110078278136832113753&rtpof=true&sd=true">Become a Sponsor</a><br />
+<a href="/about/participant-protection">Participant Protection</a><br /><br />
+                            </p>
+                        </div>
+                                                <div class="col-md- col">
+                            <p class="">
+                                <strong>Awards</strong><br />
+                                <a href="/awards/hall-of-fame">Hall of Fame</a><br />
+<a href="/awards/espirit-de-corps">Espirit De Corps</a><br />
+<a href="/awards/most-improved">Most Improved</a><br />
+<a href="/awards/staff-volunteer-of-the-year">Staff/Volunteer of the Year</a>                            </p>
+                        </div>
+                                                <div class="col-md- col">
+                            <p class="">
+                                <strong>Social</strong><br />
+                                <a href="https://www.facebook.com/TheRMPA" target="_blank">Facebook</a><br />
+<a href="https://www.instagram.com/rmpa93" target="_blank">Instagram</a><br />                            </p>
+                        </div>
+                                            </div>
+                </div>
+            </div>
+        </footer>
+    
+        <!-- Modal -->
+        <div class="modal fade" id="my_modal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel">
+            <div class="modal-dialog" role="document">
+                <div class="modal-content">
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                        <i class="bi bi-x-lg"></i>
+                        <!-- <i class="fas fa-times"></i> -->
+                    </button>
+                    <div class="modal-body">
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Ensemble Search -->
+        <div class="ensemble-search-form hide-on-load">
+            <h1>Group Search</h1>
+
+            <div class="hide-on-load">
+                <input type="text" name="username" />
+                <input type="password" name="password" />
+            </div>
+
+            <div class="switch-sites-list">
+                <form method="post" action="//rmpa.org/main/load" id="view-ensemble">
+                    <input type="text" class="form-control typeahead-search" name="ensemble" placeholder="Type Name" />
+                </form>
+            </div>
+            <div id="site-list-login" class="hide-on-load">Alameda International HS,Arapahoe High School,Arvada High School,Bear Creek High School Percussion Ensemble,Black Diamond Percussion ,Blue Knights Percussion Ensemble,Blue Knights Winds,Broomfield High School,Burlington Cougar Drumline,Ca&ntilde;on City Tiger Pride Winter Percussion,Castle View in Douglas County,Centaurus Winter Percussion Ensemble,Chaparral High School Winter Percussion Ensemble,Columbine High School,Columbine High School,D'Evelyn Percussion Ensemble,D49indoor,Dakota Ridge High School,Dakota Ridge High School,Denver South Rebels,District 49 Winter Percussion,Doherty High School Percussion Ensemble,Douglas County High School Winter Percussion,Eaglecrest High School,Eaglecrest High School,Englewood High School Percussion Ensemble,Evergreen High School Winter Percussion,Fairivew High School ,Fossil Ridge Winter Percussion,Fountain-Fort Carson High School Percussion Ensemble,Gateway High School Percussion Ensemble,Great Oak High School,Harrison District 2 Percussion Ensemble,Heritage High School Winter Percussion,Highlands Ranch Falcon Percussion,Joeâ€™s test to help Burlington ,Lakewood Winter Percussion Ensemble,Legacy High School Winter Percussion,Legend Titan Percussion Ensemble,Longmont Winter Percussion,Loveland Indoor Percussion,Mesa Ridge Percussion Ensemble,Monarch Indoor Percussion,Mountain Range High School,Mountain Vista Percussion Ensemble,Pine Creek High School,Pomona High School Winds,Ponderosa High School,Prairie View High School,Pueblo Central High School ,Pueblo Central High School,Pueblo City Schools Indoor Percussion,Rampart High School,Rangeview High School,Rise Percussion,Rise Percussion Concert,Rise2,Rise2 Concert,Rock Canyon High School,Standley Lake High School,Test,Test,ThunderRidge High School,West High School Drumline,West High School Drumline,Wheat Ridge HS Winter Percussion,William J. Palmer High School,Windsor Percussion Ensemble </div>
+        </div>
+
+        <!-- About -->
+        <div class="about-page hide-on-load">
+            <h1>About</h1>
+            <div class="row">
+                <div class="col-12 col-lg-3 mb-3">
+                    <div class="nav flex-column nav-pills" id="v-pills-tab" role="tablist" aria-orientation="vertical">
+                        <a class="nav-link active" id="v-pills-home-tab" data-toggle="pill" href="#v-pills-home" role="tab" aria-controls="v-pills-home" aria-selected="true">Who We Are</a>
+                        <a class="nav-link" id="v-pills-profile-tab" data-toggle="pill" href="#v-pills-profile" role="tab" aria-controls="v-pills-profile" aria-selected="false">Address</a>
+                        <a class="nav-link" id="v-pills-messages-tab" data-toggle="pill" href="#v-pills-messages" role="tab" aria-controls="v-pills-messages" aria-selected="false">Contacts</a>
+                        <a class="nav-link" id="v-pills-agreement-tab" data-toggle="pill" href="#v-pills-agreement" role="tab" aria-controls="v-pills-agreement" aria-selected="false">Master Agreement</a>
+                        <a class="nav-link" id="v-pills-handbook-tab" data-toggle="pill" href="#v-pills-handbook" role="tab" aria-controls="v-pills-handbook" aria-selected="false">Handbook</a>
+                    </div>
+                </div>
+                <div class="col-12 col-lg-9">
+                    <div class="tab-content" id="v-pills-tabContent">
+                        <div class="tab-pane fade show active" id="v-pills-home" role="tabpanel" aria-labelledby="v-pills-home-tab">
+                            <p style="text-align: left;"><strong>Mission Statement</strong></p>
+<p style="text-align: left;"><span id="docs-internal-guid-90c188d6-7fff-2ad4-c58c-6093fe306017"><span>The Rocky Mountain Percussion Association commits to providing a competitive performance outlet supporting music education in the rocky mountain region; enriching the lives of young performers through an inclusive and supportive environment where young performers develop their skills, confidence, and passion.</span></span></p>
+<p style="text-align: left;"><strong>Our Story</strong></p>
+<p style="text-align: left;"><strong></strong>The Rocky Mountain Percussion Association is a 501(c)3 not-for-profit Colorado based youth organization, that was started in 1991 by a group of percussion instructors, judges and educators who were concerned about the level of percussion training and performance, primarily at the high school level. Steve Yates, Joe Bartko and Ralph Hardimon were the founders of the RMPA and along with Charles Craig formed what is now one of the nation&rsquo;s premier percussion organizations of its kind. Our main focus is student motivation, educational training, and achievement through the percussion activity.</p>
+<p style="text-align: left;">The association is the governing body of the indoor percussion activity in the Rocky Mountain region and sponsors a series of indoor percussion events, educational clinics and competitions during the winter and spring months.</p>
+<p style="text-align: left;">These programs provide a motivational tool that can help turn non-percussionists and a typical drum section into a cohesive and entertaining percussion ensemble. The nation&rsquo;s top percussion judges adjudicate all of our competitions.</p>
+<p style="text-align: left;">Since the first event was held in 1993, the RMPA has provided competition and training for over 15,000 students, and has become one of the premier percussion organizations of its kind in the country and serves as a national model by which other organizations are administered and managed.</p>
+<p style="text-align: left;"><strong>Winter Percussion</strong></p>
+<p style="text-align: left;">The Winter Percussion Activity was organized to provide a program for the many percussion students participating in a typical marching band during the fall season, but not having a comparable performance outlet during the winter and spring seasons. The traditional jazz band, concert band, wind ensemble, etc. does not involve the larger number of percussion students that a marching band requires.</p>
+<p style="text-align: left;">The first units participating in the percussion activity were primarily from scholastic marching units, utilizing both a battery and pit ensemble in a setting that limited the amount of marching and showmanship. Within a few short years, the number of independent organizations participating in the competitions increased, and the performance venue was enlarged to allow for more development of the visual and theatrical potential of the activity. Soon thereafter, traditional &ldquo;concert&rdquo; percussion ensembles were included as an additional performance outlet for student percussionists preferring that genre.</p>
+<p style="text-align: left;"><span>The Rocky Mountain Percussion Association operates under the rules and guidelines of Winter Guard International.</span></p>                        </div>
+                        <div class="tab-pane fade" id="v-pills-profile" role="tabpanel" aria-labelledby="v-pills-profile-tab">
+                            <p>PO Box 184</p>
+<p>Broomfield, CO 80038</p>                        </div>
+                        <div class="tab-pane fade" id="v-pills-messages" role="tabpanel" aria-labelledby="v-pills-messages-tab">
+                            <p><strong>2025-2026 Board of Directors</strong></p>
+<ul>
+<li>President -&nbsp;Colin Spear ~ <a href="mailto:colin@rmpa.org">colin@rmpa.org</a></li>
+<li>Vice President - Scott Wilson ~ <a href="mailto:scott@rmpa.org">scott@rmpa.org</a></li>
+<li>Treasurer - Lori Nonies ~&nbsp;<a href="mailto:lori@rmpa.org">lori@rmpa.org</a></li>
+<li>Secretary -&nbsp;Lynn Collins ~&nbsp;<a href="mailto:lynn@rmpa.org">lynn@rmpa.org</a></li>
+<li>Marketing Director - Dylan Kroha ~ <a href="mailto:dylan@rmpa.org">dylan@rmpa.org</a></li>
+<li>Director of Education and Development - Tanner Homa ~ <a href="mailto:tanner@rmpa.org">tanner@rmpa.org</a></li>
+<li>Director of Education and Development - Julian Davidson ~&nbsp;<a href="mailto:julian@rmpa.org">julian@rmpa.org</a></li>
+</ul>
+<p><strong>2025-2026 Support Team</strong></p>
+<ul>
+<li>Financial Secretary - Erin Moore ~&nbsp;<a href="mailto:erin@affinity.cpa">erin@affinity.cpa</a></li>
+</ul>
+<p><strong>Founding Members&nbsp;<small>(circa 1991)</small></strong></p>
+<ul>
+<li>Steve Yates</li>
+<li>Ralph Hardimon</li>
+<li>Joe Bartko</li>
+<li>Charles Craig</li>
+</ul>
+<ul>
+</ul>                        </div>
+                        <div class="tab-pane fade" id="v-pills-agreement" role="tabpanel" aria-labelledby="v-pills-agreement-tab">
+                            <p>Coming Soon...</p>                        </div>
+                        <div class="tab-pane fade" id="v-pills-handbook" role="tabpanel" aria-labelledby="v-pills-handbook-tab">
+                            <p><a href="https://docs.google.com/document/d/e/2PACX-1vS3IJA3VlrkGYLvh_FLqyCmkVGR-b-Jr4d4UXcjLtVPXp6ZTb3rOSSy88eZHtpRA-E7BYUQQwTc2lx3/pub"> 2026 RMPA Member Handbook&nbsp;</a>This document will be a must-read for all directors, instructors, and performers.</p>                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+ 
+        <!-- Newsletter Signup Form -->
+        <div class="newsletter_form hide-on-load">
+            <h1>Newsletter Signup</h1>
+
+            <div class="hide-on-load">
+                <input type="text" name="username" />
+                <input type="password" name="password" />
+            </div>
+
+            <div class="newsletter-submission-status"></div>
+
+            <div class="newsletter-submission-frame">
+                <div class="form-group">
+                    <div class="row">
+                        <div class="col-4"><label>Name</label></div>
+                        <div class="col-8"><input type="text" name="name" value="" placeholder="Name" class="form-control newsletter-name" /></div>
+                    </div>
+                </div>
+
+                <div class="form-group">
+                    <div class="row">
+                        <div class="col-4"><label>Email</label></div>
+                        <div class="col-8"><input type="text" name="email" value="" placeholder="Email" class="form-control newsletter-email" /></div>
+                    </div>
+                </div>
+
+                <div class="form-group">
+                    <div class="row">
+                        <div class="col-4"><label>&nbsp;</label></div>
+                        <div class="col-8"><input type="button" name="submit" value="Submit" class="btn btn-primary newsletter-submit" /></div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Login Form -->
+        <div class="login_form hide-on-load">
+            <h1>Login</h1>
+
+                                <p><small>* Only registered will display in list</small></p>
+
+                    <div class="login_response"></div>
+
+                    <div class="hide-on-load">
+                        <input type="text" name="username" />
+                        <input type="password" name="password" />
+                    </div>
+
+                    <div class="switch-sites-list">
+                        <input type="text" class="form-control typeahead-search" name="ensemble" placeholder="Type Name" />
+                    </div>
+                    <div id="site-list-login" class="hide-on-load">Alameda International HS,Arapahoe High School,Arvada High School,Bear Creek High School Percussion Ensemble,Black Diamond Percussion ,Blue Knights Percussion Ensemble,Blue Knights Winds,Broomfield High School,Burlington Cougar Drumline,Ca&ntilde;on City Tiger Pride Winter Percussion,Castle View in Douglas County,Centaurus Winter Percussion Ensemble,Chaparral High School Winter Percussion Ensemble,Columbine High School,Columbine High School,D'Evelyn Percussion Ensemble,D49indoor,Dakota Ridge High School,Dakota Ridge High School,Denver South Rebels,District 49 Winter Percussion,Doherty High School Percussion Ensemble,Douglas County High School Winter Percussion,Eaglecrest High School,Eaglecrest High School,Englewood High School Percussion Ensemble,Evergreen High School Winter Percussion,Fairivew High School ,Fossil Ridge Winter Percussion,Fountain-Fort Carson High School Percussion Ensemble,Gateway High School Percussion Ensemble,Great Oak High School,Harrison District 2 Percussion Ensemble,Heritage High School Winter Percussion,Highlands Ranch Falcon Percussion,Joeâ€™s test to help Burlington ,Lakewood Winter Percussion Ensemble,Legacy High School Winter Percussion,Legend Titan Percussion Ensemble,Longmont Winter Percussion,Loveland Indoor Percussion,Mesa Ridge Percussion Ensemble,Monarch Indoor Percussion,Mountain Range High School,Mountain Vista Percussion Ensemble,Pine Creek High School,Pomona High School Winds,Ponderosa High School,Prairie View High School,Pueblo Central High School ,Pueblo Central High School,Pueblo City Schools Indoor Percussion,Rampart High School,Rangeview High School,Rise Percussion,Rise Percussion Concert,Rise2,Rise2 Concert,Rock Canyon High School,Standley Lake High School,Test,Test,ThunderRidge High School,West High School Drumline,West High School Drumline,Wheat Ridge HS Winter Percussion,William J. Palmer High School,Windsor Percussion Ensemble </div>
+
+                    <br />
+                    <div class="hide-on-load">
+                        <input type="text" name="username" />
+                        <input type="password" name="password" />
+                    </div>
+                    <input type="password" value="" class="form-control password" placeholder="Password" />
+                    <br />
+                    
+                    <input type="submit" class="btn btn-primary login_now" value="Login" /> 
+                    
+                    <div class="clearfix"></div>
+                    <br />
+
+                    <p><a href="//rmpa.org/ensemble/forgot">Forgot Password</a><!--  | <a href="#" class="toggle_type"><span class="login_type">Judge</span> Login</a> --></p>
+
+                            </div>
+
+        <script src="//ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
+        <script>window.jQuery || document.write('<script src="//rmpa.org/theme/main/assets/js/vendor/jquery-3.3.1.min.js"><\/script>')</script>
+        <script>
+            var site_url = "//rmpa.org";
+        </script>
+        <script src="//rmpa.org/theme/main/assets/js/vendor/bootstrap.min.js?v=2"></script>
+        <script src="//rmpa.org/theme/main/assets/js/typeahead.js"></script>
+        <script src="//rmpa.org/theme/main/assets/js/main.js?v=11"></script>
+
+            </body>
+</html>

--- a/data/test-fixtures/schedule-single-retreat.html
+++ b/data/test-fixtures/schedule-single-retreat.html
@@ -1,0 +1,225 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8" />
+<title>RMPA Show #1   Schedule</title>
+<style>
+* {
+    -webkit-box-sizing: border-box;
+    -moz-box-sizing: border-box;
+    box-sizing: border-box;
+    font-family: Arial, sans-serif;
+}
+
+.event-details {
+    width: 650px;
+    margin: auto auto 20px;
+}
+
+.event-details__logo {
+    float: right;
+}
+
+.clearfix:after { 
+   content: '.'; 
+   visibility: hidden; 
+   display: block; 
+   height: 0; 
+   clear: both;
+}
+
+.event-details__event-name {
+    font-size: 20px;
+    font-weight:bold;
+}
+
+.event-details__competition-name {
+    font-size: 14px;
+    margin-left: 15px;
+    margin-top: 5px;
+}
+
+.event-details__location {
+    font-size: 14px;
+    font-style: italic;
+    margin-left: 15px;
+    margin-top: 5px;
+}
+
+.schedule-note {
+    margin: auto;
+    width: 575px;
+    font-weight: bold;
+    text-align: center;
+}
+
+.schedule-area {
+    width: 715px;
+    margin: auto;
+    border-top: solid 1px #999;
+    font-size: 15px;
+}
+
+.schedule-row {
+    border-bottom: solid 1px #999;
+    padding: 10px 0 10px 0;
+}
+
+.schedule-row__custom {
+    display: inline-block;
+    width: 550px;
+    overflow: hidden;
+    white-space: nowrap;
+    vertical-align: middle;
+    -ms-text-overflow: ellipsis;
+    text-overflow: ellipsis;
+    padding-left: 40px;
+}
+
+.schedule-row__name {
+    display: inline-block;
+    width: 250px;
+    overflow: hidden;
+    white-space: nowrap;
+    vertical-align: middle;
+    -ms-text-overflow: ellipsis;
+    text-overflow: ellipsis;
+}
+
+.schedule-row__location {
+    display: inline-block;
+    width: 240px;
+    overflow: hidden;
+    white-space: nowrap;
+    vertical-align: middle;
+    -ms-text-overflow: ellipsis;
+    text-overflow: ellipsis;
+}
+
+.schedule-row__initials {
+    display: inline-block;
+    width: 110px;
+    text-align: center;
+    overflow: hidden;
+    white-space: nowrap;
+    vertical-align: middle;
+}
+
+.schedule-row__time {
+    display: inline-block;
+    width: 100px;
+    text-align: right;
+    overflow: hidden;
+    white-space: nowrap;
+    vertical-align: middle;
+}
+
+pre {
+    white-space: normal;
+}
+
+.generation-date {
+    margin-top: 20px;
+    font-size: 10px;
+    text-align: center;
+    color: #999;
+    font-style: italic;
+}
+
+
+</style>
+</head>
+<body>
+<div class='event-details clearfix'>
+<div class='event-details__logo'><img src='https://s3.amazonaws.com/competitionsuite/logos/36/02707e1de2be41d391512f466f6dc115.png' style='max-height: 75px; max-width: 135px' alt='Logo' /></div><div class='event-details__event-name'>RMPA Show #1</div><div class='event-details__location'>Saturday, February 14, 2026 - Monarch High School</div></div>
+<div class='schedule-note'><pre>329 Campus Dr
+Louisville, CO 80027</pre></div><div class='schedule-area'><div class='schedule-row '><div class='schedule-row__name'>Conifer HS Lobo Percussion</div>
+<div class='schedule-row__location'>Conifer, CO</div>
+<div class='schedule-row__initials'>PSSRA</div>
+<div class='schedule-row__time'>12:10 PM</div></div><div class='schedule-row '><div class='schedule-row__name'>Mountain Range High School</div>
+<div class='schedule-row__location'>Westminster, Colorado</div>
+<div class='schedule-row__initials'>PSRA</div>
+<div class='schedule-row__time'>12:20 PM</div></div><div class='schedule-row '><div class='schedule-row__name'>Legend High School</div>
+<div class='schedule-row__location'>Parker, CO</div>
+<div class='schedule-row__initials'>PSRA</div>
+<div class='schedule-row__time'>12:30 PM</div></div><div class='schedule-row '><div class='schedule-row__name'>Horizon High School Winter Percussion</div>
+<div class='schedule-row__location'>Horizon High School</div>
+<div class='schedule-row__initials'>PSRA</div>
+<div class='schedule-row__time'>12:40 PM</div></div><div class='schedule-row '><div class='schedule-row__name'>Frederick High School</div>
+<div class='schedule-row__location'>Frederick, Colorado</div>
+<div class='schedule-row__initials'>PSRA</div>
+<div class='schedule-row__time'>12:50 PM</div></div><div class='schedule-row '><div class='schedule-row__name'>Mountain Vista Winter Percussion</div>
+<div class='schedule-row__location'>Highlands Ranch</div>
+<div class='schedule-row__initials'>PSRA</div>
+<div class='schedule-row__time'>1:00 PM</div></div><div class='schedule-row schedule-row--custom'><div class='schedule-row__custom'>Lunch</div><div class='schedule-row__time'>1:10 PM</div></div><div class='schedule-row '><div class='schedule-row__name'>Evergreen High School</div>
+<div class='schedule-row__location'>Evergreen, Colorado</div>
+<div class='schedule-row__initials'>PSCA</div>
+<div class='schedule-row__time'>2:20 PM</div></div><div class='schedule-row '><div class='schedule-row__name'>TCA Winter Percussion Ensemble</div>
+<div class='schedule-row__location'>COlorado Springs</div>
+<div class='schedule-row__initials'>PSCA</div>
+<div class='schedule-row__time'>2:30 PM</div></div><div class='schedule-row '><div class='schedule-row__name'>Dakota Ridge High School</div>
+<div class='schedule-row__location'>Littleton, Colorado</div>
+<div class='schedule-row__initials'>PSCA</div>
+<div class='schedule-row__time'>2:40 PM</div></div><div class='schedule-row '><div class='schedule-row__name'>Lakewood Winter Percussion</div>
+<div class='schedule-row__location'>Lakewood</div>
+<div class='schedule-row__initials'>PSSA</div>
+<div class='schedule-row__time'>2:50 PM</div></div><div class='schedule-row '><div class='schedule-row__name'>Longmont Winter Percussion</div>
+<div class='schedule-row__location'>Longmont, Colorado</div>
+<div class='schedule-row__initials'>PSA</div>
+<div class='schedule-row__time'>3:00 PM</div></div><div class='schedule-row '><div class='schedule-row__name'>Centaurus Winter Percussion Ensemble</div>
+<div class='schedule-row__location'>Lafayette, Colorado</div>
+<div class='schedule-row__initials'>PSA</div>
+<div class='schedule-row__time'>3:10 PM</div></div><div class='schedule-row '><div class='schedule-row__name'>Standley Lake High School</div>
+<div class='schedule-row__location'>Westminster, Colorado</div>
+<div class='schedule-row__initials'>PSA</div>
+<div class='schedule-row__time'>3:20 PM</div></div><div class='schedule-row schedule-row--custom'><div class='schedule-row__custom'>Break</div><div class='schedule-row__time'>3:30 PM</div></div><div class='schedule-row '><div class='schedule-row__name'>Bear Creek High School Percussion Ensemble</div>
+<div class='schedule-row__location'>Lakewood, Colorado</div>
+<div class='schedule-row__initials'>PSCO</div>
+<div class='schedule-row__time'>3:40 PM</div></div><div class='schedule-row '><div class='schedule-row__name'>Legacy Winter Percussion</div>
+<div class='schedule-row__location'>Broomfield</div>
+<div class='schedule-row__initials'>PSO</div>
+<div class='schedule-row__time'>3:51 PM</div></div><div class='schedule-row '><div class='schedule-row__name'>Monarch Indoor Percussion</div>
+<div class='schedule-row__location'>Louisville, Colorado</div>
+<div class='schedule-row__initials'>PSO</div>
+<div class='schedule-row__time'>4:02 PM</div></div><div class='schedule-row '><div class='schedule-row__name'>Heritage Indoor Percussion</div>
+<div class='schedule-row__location'>Littleton, CO</div>
+<div class='schedule-row__initials'>PSO</div>
+<div class='schedule-row__time'>4:13 PM</div></div><div class='schedule-row '><div class='schedule-row__name'>Loveland Indoor Percussion</div>
+<div class='schedule-row__location'>Loveland, CO</div>
+<div class='schedule-row__initials'>PSO</div>
+<div class='schedule-row__time'>4:24 PM</div></div><div class='schedule-row schedule-row--custom'><div class='schedule-row__custom'>Break</div><div class='schedule-row__time'>4:35 PM</div></div><div class='schedule-row '><div class='schedule-row__name'>BKO</div>
+<div class='schedule-row__location'>Denver, Colorado</div>
+<div class='schedule-row__initials'>PIO</div>
+<div class='schedule-row__time'>4:50 PM</div></div><div class='schedule-row '><div class='schedule-row__name'>Rise Percussion</div>
+<div class='schedule-row__location'>Denver, CO</div>
+<div class='schedule-row__initials'>PIW</div>
+<div class='schedule-row__time'>5:01 PM</div></div><div class='schedule-row schedule-row--custom'><div class='schedule-row__custom'>Performances Conclude</div><div class='schedule-row__time'>5:13 PM</div></div><div class='schedule-row schedule-row--custom'><div class='schedule-row__custom'>Retreat/Critique</div><div class='schedule-row__time'>5:28 PM</div></div></div>
+<div class='schedule-note'><pre>Admission - Adults: $14 Seniors/Students: $10 
+8 & Under: FREE</pre></div><div class='generation-date'>Generation Date: <span data-moment-full='2/12/2026 6:14:49 PM'></span></div><script crossorigin='anonymous' src='https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.1/jquery.min.js' type='text/javascript'></script>
+<script type='text/javascript' crossorigin='anonymous' src='https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.13.0/moment.min.js'></script>
+<script type='text/javascript'>
+function fixDates() {
+        $('[data-moment]').each(function (i, item) {
+            var d = moment($(item).attr('data - moment'));
+            $(item).html(d.format('l'));
+        });
+        $('[data-moment-utc]').each(function (i, item)
+        {
+            var d = moment.utc($(item).attr('data-moment-utc'));
+            $(item).html(d.format('l'));
+        });
+        $('[data-moment-time]').each(function (i, item)
+        {
+            var d = moment($(item).attr('data-moment-time'));
+            $(item).html(d.format('LT'));
+        });
+        $('[data-moment-full]').each(function (i, item)
+        {
+            var d = moment($(item).attr('data-moment-full') + '-0:00');
+            $(item).html(d.format('l') + ' ' + d.format('LT'));
+        });
+    }
+    fixDates();
+</script>
+</body>
+</html>

--- a/data/test-fixtures/schedule-split-retreat.html
+++ b/data/test-fixtures/schedule-split-retreat.html
@@ -1,0 +1,248 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8" />
+<title>RMPA Show #3   Schedule</title>
+<style>
+* {
+    -webkit-box-sizing: border-box;
+    -moz-box-sizing: border-box;
+    box-sizing: border-box;
+    font-family: Arial, sans-serif;
+}
+
+.event-details {
+    width: 650px;
+    margin: auto auto 20px;
+}
+
+.event-details__logo {
+    float: right;
+}
+
+.clearfix:after { 
+   content: '.'; 
+   visibility: hidden; 
+   display: block; 
+   height: 0; 
+   clear: both;
+}
+
+.event-details__event-name {
+    font-size: 20px;
+    font-weight:bold;
+}
+
+.event-details__competition-name {
+    font-size: 14px;
+    margin-left: 15px;
+    margin-top: 5px;
+}
+
+.event-details__location {
+    font-size: 14px;
+    font-style: italic;
+    margin-left: 15px;
+    margin-top: 5px;
+}
+
+.schedule-note {
+    margin: auto;
+    width: 575px;
+    font-weight: bold;
+    text-align: center;
+}
+
+.schedule-area {
+    width: 715px;
+    margin: auto;
+    border-top: solid 1px #999;
+    font-size: 15px;
+}
+
+.schedule-row {
+    border-bottom: solid 1px #999;
+    padding: 10px 0 10px 0;
+}
+
+.schedule-row__custom {
+    display: inline-block;
+    width: 550px;
+    overflow: hidden;
+    white-space: nowrap;
+    vertical-align: middle;
+    -ms-text-overflow: ellipsis;
+    text-overflow: ellipsis;
+    padding-left: 40px;
+}
+
+.schedule-row__name {
+    display: inline-block;
+    width: 250px;
+    overflow: hidden;
+    white-space: nowrap;
+    vertical-align: middle;
+    -ms-text-overflow: ellipsis;
+    text-overflow: ellipsis;
+}
+
+.schedule-row__location {
+    display: inline-block;
+    width: 240px;
+    overflow: hidden;
+    white-space: nowrap;
+    vertical-align: middle;
+    -ms-text-overflow: ellipsis;
+    text-overflow: ellipsis;
+}
+
+.schedule-row__initials {
+    display: inline-block;
+    width: 110px;
+    text-align: center;
+    overflow: hidden;
+    white-space: nowrap;
+    vertical-align: middle;
+}
+
+.schedule-row__time {
+    display: inline-block;
+    width: 100px;
+    text-align: right;
+    overflow: hidden;
+    white-space: nowrap;
+    vertical-align: middle;
+}
+
+pre {
+    white-space: normal;
+}
+
+.generation-date {
+    margin-top: 20px;
+    font-size: 10px;
+    text-align: center;
+    color: #999;
+    font-style: italic;
+}
+
+
+</style>
+</head>
+<body>
+<div class='event-details clearfix'>
+<div class='event-details__logo'><img src='https://s3.amazonaws.com/competitionsuite/logos/36/02707e1de2be41d391512f466f6dc115.png' style='max-height: 75px; max-width: 135px' alt='Logo' /></div><div class='event-details__event-name'>RMPA Show #3</div><div class='event-details__location'>Saturday, February 28, 2026 - Lakewood High School</div></div>
+<div class='schedule-note'><pre>9700 W 8th Ave, Lakewood, CO 80215
+**Note this is a split day**</pre></div><div class='schedule-area'><div class='schedule-row '><div class='schedule-row__name'>Englewood High School Zero Hour Percussion Ensemble</div>
+<div class='schedule-row__location'>Englewood , Colorado</div>
+<div class='schedule-row__initials'>PSCRA</div>
+<div class='schedule-row__time'>11:30 AM</div></div><div class='schedule-row '><div class='schedule-row__name'>Conifer HS Lobo Percussion</div>
+<div class='schedule-row__location'>Conifer, CO</div>
+<div class='schedule-row__initials'>PSSRA</div>
+<div class='schedule-row__time'>11:40 AM</div></div><div class='schedule-row '><div class='schedule-row__name'>Columbine High School</div>
+<div class='schedule-row__location'>Littleton, Colorado</div>
+<div class='schedule-row__initials'>PSRA</div>
+<div class='schedule-row__time'>11:50 AM</div></div><div class='schedule-row '><div class='schedule-row__name'>Legend High School</div>
+<div class='schedule-row__location'>Parker, CO</div>
+<div class='schedule-row__initials'>PSRA</div>
+<div class='schedule-row__time'>12:00 PM</div></div><div class='schedule-row '><div class='schedule-row__name'>Mountain Range High School</div>
+<div class='schedule-row__location'>Westminster, Colorado</div>
+<div class='schedule-row__initials'>PSRA</div>
+<div class='schedule-row__time'>12:10 PM</div></div><div class='schedule-row '><div class='schedule-row__name'>Trojan Percussion Ensemble</div>
+<div class='schedule-row__location'>Fountain, CO</div>
+<div class='schedule-row__initials'>PSRA</div>
+<div class='schedule-row__time'>12:20 PM</div></div><div class='schedule-row '><div class='schedule-row__name'>Highlands Ranch Falcon Percussion Ensemble</div>
+<div class='schedule-row__location'>Highlands Ranch, Colorado</div>
+<div class='schedule-row__initials'>PSRA</div>
+<div class='schedule-row__time'>12:30 PM</div></div><div class='schedule-row '><div class='schedule-row__name'>Windsor Percussion Ensemble</div>
+<div class='schedule-row__location'>Windsor High School, 1100 Main St., Windsor, CO 80550</div>
+<div class='schedule-row__initials'>PSRA</div>
+<div class='schedule-row__time'>12:40 PM</div></div><div class='schedule-row '><div class='schedule-row__name'>Widefield HS Winter Percussion</div>
+<div class='schedule-row__location'>Widefield High School</div>
+<div class='schedule-row__initials'>PSRA</div>
+<div class='schedule-row__time'>12:50 PM</div></div><div class='schedule-row '><div class='schedule-row__name'>Frederick High School</div>
+<div class='schedule-row__location'>Frederick, Colorado</div>
+<div class='schedule-row__initials'>PSRA</div>
+<div class='schedule-row__time'>1:00 PM</div></div><div class='schedule-row '><div class='schedule-row__name'>Horizon High School Winter Percussion</div>
+<div class='schedule-row__location'>Horizon High School</div>
+<div class='schedule-row__initials'>PSRA</div>
+<div class='schedule-row__time'>1:10 PM</div></div><div class='schedule-row '><div class='schedule-row__name'>Sand Creek Winter Percussion</div>
+<div class='schedule-row__location'>Colorado Springs, Colorado</div>
+<div class='schedule-row__initials'>PSRA</div>
+<div class='schedule-row__time'>1:20 PM</div></div><div class='schedule-row schedule-row--custom'><div class='schedule-row__custom'>Regional A Performances Conclude</div><div class='schedule-row__time'>1:30 PM</div></div><div class='schedule-row schedule-row--custom'><div class='schedule-row__custom'>Regional A Retreat/Critique</div><div class='schedule-row__time'>1:45 PM</div></div><div class='schedule-row '><div class='schedule-row__name'>Dakota Ridge High School</div>
+<div class='schedule-row__location'>Littleton, Colorado</div>
+<div class='schedule-row__initials'>PSCA</div>
+<div class='schedule-row__time'>3:25 PM</div></div><div class='schedule-row '><div class='schedule-row__name'>Evergreen High School</div>
+<div class='schedule-row__location'>Evergreen, Colorado</div>
+<div class='schedule-row__initials'>PSCA</div>
+<div class='schedule-row__time'>3:35 PM</div></div><div class='schedule-row '><div class='schedule-row__name'>Lakewood Winter Percussion</div>
+<div class='schedule-row__location'>Lakewood</div>
+<div class='schedule-row__initials'>PSSA</div>
+<div class='schedule-row__time'>3:45 PM</div></div><div class='schedule-row '><div class='schedule-row__name'>Castle View High School Percussion Ensemble</div>
+<div class='schedule-row__location'>Castle Rock, CO</div>
+<div class='schedule-row__initials'>PSSA</div>
+<div class='schedule-row__time'>3:55 PM</div></div><div class='schedule-row '><div class='schedule-row__name'>Cherry Creek High School</div>
+<div class='schedule-row__location'>Greenwood Village, CO</div>
+<div class='schedule-row__initials'>PSSA</div>
+<div class='schedule-row__time'>4:05 PM</div></div><div class='schedule-row '><div class='schedule-row__name'>The District 11 Indoor Percussion Ensemble</div>
+<div class='schedule-row__location'>301 N Nevada Ave</div>
+<div class='schedule-row__initials'>PSSA</div>
+<div class='schedule-row__time'>4:15 PM</div></div><div class='schedule-row '><div class='schedule-row__name'>Centaurus Winter Percussion Ensemble</div>
+<div class='schedule-row__location'>Lafayette, Colorado</div>
+<div class='schedule-row__initials'>PSA</div>
+<div class='schedule-row__time'>4:25 PM</div></div><div class='schedule-row '><div class='schedule-row__name'>Longmont Winter Percussion</div>
+<div class='schedule-row__location'>Longmont, Colorado</div>
+<div class='schedule-row__initials'>PSA</div>
+<div class='schedule-row__time'>4:35 PM</div></div><div class='schedule-row schedule-row--custom'><div class='schedule-row__custom'>Break</div><div class='schedule-row__time'>4:45 PM</div></div><div class='schedule-row '><div class='schedule-row__name'>Broomfield High School</div>
+<div class='schedule-row__location'>Broomfield, Colorado</div>
+<div class='schedule-row__initials'>PSCO</div>
+<div class='schedule-row__time'>4:55 PM</div></div><div class='schedule-row '><div class='schedule-row__name'>Bear Creek High School Percussion Ensemble</div>
+<div class='schedule-row__location'>Lakewood, Colorado</div>
+<div class='schedule-row__initials'>PSCO</div>
+<div class='schedule-row__time'>5:06 PM</div></div><div class='schedule-row '><div class='schedule-row__name'>Academy School District</div>
+<div class='schedule-row__location'>Colorado Springs, CO</div>
+<div class='schedule-row__initials'>PSO</div>
+<div class='schedule-row__time'>5:17 PM</div></div><div class='schedule-row '><div class='schedule-row__name'>Legacy Winter Percussion</div>
+<div class='schedule-row__location'>Broomfield</div>
+<div class='schedule-row__initials'>PSO</div>
+<div class='schedule-row__time'>5:28 PM</div></div><div class='schedule-row '><div class='schedule-row__name'>Monarch Indoor Percussion</div>
+<div class='schedule-row__location'>Louisville, Colorado</div>
+<div class='schedule-row__initials'>PSO</div>
+<div class='schedule-row__time'>5:39 PM</div></div><div class='schedule-row schedule-row--custom'><div class='schedule-row__custom'>Break</div><div class='schedule-row__time'>5:50 PM</div></div><div class='schedule-row '><div class='schedule-row__name'>BKO</div>
+<div class='schedule-row__location'>Denver, Colorado</div>
+<div class='schedule-row__initials'>PIO</div>
+<div class='schedule-row__time'>6:05 PM</div></div><div class='schedule-row '><div class='schedule-row__name'>Blue Knights Percussion Ensemble</div>
+<div class='schedule-row__location'>Denver, Colorado</div>
+<div class='schedule-row__initials'>PIW</div>
+<div class='schedule-row__time'>6:16 PM</div></div><div class='schedule-row '><div class='schedule-row__name'>Rise Percussion</div>
+<div class='schedule-row__location'>Denver, CO</div>
+<div class='schedule-row__initials'>PIW</div>
+<div class='schedule-row__time'>6:28 PM</div></div><div class='schedule-row schedule-row--custom'><div class='schedule-row__custom'>Performances Conclude</div><div class='schedule-row__time'>6:40 PM</div></div><div class='schedule-row schedule-row--custom'><div class='schedule-row__custom'>Retreat/Critique</div><div class='schedule-row__time'>6:55 PM</div></div></div>
+<div class='schedule-note'><pre>Admission - Adults: $10 Block 1 $14 Block 2 or Full Day Seniors/Students: $8 Block 1 $10 Full Day or Block 2 8 & Under: FREE</pre></div><div class='generation-date'>Generation Date: <span data-moment-full='2/23/2026 10:20:57 PM'></span></div><script crossorigin='anonymous' src='https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.1/jquery.min.js' type='text/javascript'></script>
+<script type='text/javascript' crossorigin='anonymous' src='https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.13.0/moment.min.js'></script>
+<script type='text/javascript'>
+function fixDates() {
+        $('[data-moment]').each(function (i, item) {
+            var d = moment($(item).attr('data - moment'));
+            $(item).html(d.format('l'));
+        });
+        $('[data-moment-utc]').each(function (i, item)
+        {
+            var d = moment.utc($(item).attr('data-moment-utc'));
+            $(item).html(d.format('l'));
+        });
+        $('[data-moment-time]').each(function (i, item)
+        {
+            var d = moment($(item).attr('data-moment-time'));
+            $(item).html(d.format('LT'));
+        });
+        $('[data-moment-full]').each(function (i, item)
+        {
+            var d = moment($(item).attr('data-moment-full') + '-0:00');
+            $(item).html(d.format('l') + ' ' + d.format('LT'));
+        });
+    }
+    fixDates();
+</script>
+</body>
+</html>

--- a/src/pipeline/commit.ts
+++ b/src/pipeline/commit.ts
@@ -1,0 +1,68 @@
+import { execSync } from 'node:child_process'
+import type { ShowData } from '../types'
+
+// ---------------------------------------------------------------------------
+// Functions
+// ---------------------------------------------------------------------------
+
+function git(command: string): string {
+  return execSync(`git ${command}`, { encoding: 'utf-8' }).trim()
+}
+
+function commitNewShow(showData: ShowData, files: Array<string>): void {
+  const { metadata } = showData
+  const classCount = showData.classes.length
+  const ensembleCount = showData.classes.reduce((sum, c) => sum + c.ensembles.length, 0)
+  const classNames = showData.classes.map((c) => c.classDef.name).join(', ')
+
+  for (const file of files) {
+    git(`add "${file}"`)
+  }
+
+  const message = [
+    `chore(data): add scores for ${metadata.eventName} (${metadata.date})`,
+    '',
+    `Classes: ${classNames}`,
+    `Ensembles: ${ensembleCount} ensembles across ${classCount} classes`,
+    '',
+    'Automated by: score-ingestion-pipeline',
+  ].join('\n')
+
+  git(`commit -m "${message.replace(/"/g, '\\"')}"`)
+}
+
+function commitUpdatedShow(
+  showData: ShowData,
+  files: Array<string>,
+  reason: string,
+  oldHash: string,
+  newHash: string,
+): void {
+  const { metadata } = showData
+
+  for (const file of files) {
+    git(`add "${file}"`)
+  }
+
+  const message = [
+    `chore(data): update scores for ${metadata.eventName} (${metadata.date})`,
+    '',
+    `Reason: ${reason}`,
+    `Hash: ${oldHash.slice(0, 8)} → ${newHash.slice(0, 8)}`,
+    '',
+    'Automated by: score-ingestion-pipeline',
+  ].join('\n')
+
+  git(`commit -m "${message.replace(/"/g, '\\"')}"`)
+}
+
+function commitPollState(message: string): void {
+  git('add public/data/poll-state.json')
+  git(`commit -m "chore(data): ${message}\n\nAutomated by: score-ingestion-pipeline"`)
+}
+
+// ---------------------------------------------------------------------------
+// Exports
+// ---------------------------------------------------------------------------
+
+export { commitNewShow, commitUpdatedShow, commitPollState }

--- a/src/pipeline/contentHash.test.ts
+++ b/src/pipeline/contentHash.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest'
+import { hashContent, compareHash } from './contentHash'
+
+describe('hashContent', () => {
+  it('should return a 64-character hex string (SHA-256)', () => {
+    const hash = hashContent('<html><body>scores</body></html>')
+    expect(hash).toMatch(/^[0-9a-f]{64}$/)
+  })
+
+  it('should be deterministic — same input always same hash', () => {
+    const html = '<html><body>hello world</body></html>'
+    expect(hashContent(html)).toBe(hashContent(html))
+  })
+
+  it('should produce different hashes for different content', () => {
+    const h1 = hashContent('<html>version 1</html>')
+    const h2 = hashContent('<html>version 2</html>')
+    expect(h1).not.toBe(h2)
+  })
+
+  it('should handle empty string', () => {
+    const hash = hashContent('')
+    expect(hash).toMatch(/^[0-9a-f]{64}$/)
+  })
+})
+
+describe('compareHash', () => {
+  it('should return "new" when previous hash is null', () => {
+    const result = compareHash('abc123', null)
+    expect(result.status).toBe('new')
+    expect(result.currentHash).toBe('abc123')
+    expect(result.previousHash).toBeNull()
+  })
+
+  it('should return "unchanged" when hashes match', () => {
+    const result = compareHash('abc123', 'abc123')
+    expect(result.status).toBe('unchanged')
+  })
+
+  it('should return "changed" when hashes differ', () => {
+    const result = compareHash('abc123', 'def456')
+    expect(result.status).toBe('changed')
+    expect(result.currentHash).toBe('abc123')
+    expect(result.previousHash).toBe('def456')
+  })
+})

--- a/src/pipeline/contentHash.ts
+++ b/src/pipeline/contentHash.ts
@@ -1,0 +1,39 @@
+import { createHash } from 'node:crypto'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type HashStatus = 'new' | 'changed' | 'unchanged'
+
+type HashComparison = {
+  status: HashStatus
+  currentHash: string
+  previousHash: string | null
+}
+
+// ---------------------------------------------------------------------------
+// Functions
+// ---------------------------------------------------------------------------
+
+function hashContent(html: string): string {
+  return createHash('sha256').update(html, 'utf-8').digest('hex')
+}
+
+function compareHash(currentHash: string, previousHash: string | null): HashComparison {
+  if (previousHash === null) {
+    return { status: 'new', currentHash, previousHash }
+  }
+  return {
+    status: currentHash === previousHash ? 'unchanged' : 'changed',
+    currentHash,
+    previousHash,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Exports
+// ---------------------------------------------------------------------------
+
+export { hashContent, compareHash }
+export type { HashStatus, HashComparison }

--- a/src/pipeline/pollState.test.ts
+++ b/src/pipeline/pollState.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect } from 'vitest'
+import {
+  findActionableRetreats,
+  isCoolDownActive,
+  hasWork,
+  markRetreatImported,
+  markRetreatFailed,
+  addOrUpdateRetreat,
+  makeRetreatEntry,
+  emptyPollState,
+  COOL_DOWN_MINUTES,
+} from './pollState'
+import type { PollState } from './pollState'
+
+function makeState(overrides: Partial<PollState> = {}): PollState {
+  return { ...emptyPollState(2026), ...overrides }
+}
+
+describe('findActionableRetreats', () => {
+  it('should return empty when no retreats exist', () => {
+    const state = makeState()
+    expect(findActionableRetreats(state, new Date())).toEqual([])
+  })
+
+  it('should return empty when retreat is in the future', () => {
+    const entry = makeRetreatEntry('2026-03-01', 'Show #1', '2026-03-01T23:00:00Z')
+    const state = makeState({ retreats: [entry] })
+    const now = new Date('2026-03-01T20:00:00Z')
+    expect(findActionableRetreats(state, now)).toEqual([])
+  })
+
+  it('should return retreat when now is within the window', () => {
+    const entry = makeRetreatEntry('2026-03-01', 'Show #1', '2026-03-01T23:00:00Z')
+    const state = makeState({ retreats: [entry] })
+    const now = new Date('2026-03-01T23:30:00Z')
+    expect(findActionableRetreats(state, now)).toHaveLength(1)
+    expect(findActionableRetreats(state, now)[0].eventName).toBe('Show #1')
+  })
+
+  it('should return empty when now is past the window close', () => {
+    const entry = makeRetreatEntry('2026-03-01', 'Show #1', '2026-03-01T23:00:00Z')
+    const state = makeState({ retreats: [entry] })
+    const now = new Date('2026-03-02T02:00:00Z') // 3 hours after retreat
+    expect(findActionableRetreats(state, now)).toEqual([])
+  })
+
+  it('should not return imported retreats', () => {
+    const entry = { ...makeRetreatEntry('2026-03-01', 'Show #1', '2026-03-01T23:00:00Z'), status: 'imported' as const, sourceHash: 'abc', lastImportedUtc: '2026-03-01T23:30:00Z' }
+    const state = makeState({ retreats: [entry] })
+    const now = new Date('2026-03-01T23:30:00Z')
+    expect(findActionableRetreats(state, now)).toEqual([])
+  })
+
+  it('should not return failed retreats', () => {
+    const entry = { ...makeRetreatEntry('2026-03-01', 'Show #1', '2026-03-01T23:00:00Z'), status: 'failed' as const }
+    const state = makeState({ retreats: [entry] })
+    const now = new Date('2026-03-01T23:30:00Z')
+    expect(findActionableRetreats(state, now)).toEqual([])
+  })
+})
+
+describe('isCoolDownActive', () => {
+  it('should return false when no cool-down is set', () => {
+    expect(isCoolDownActive(makeState(), new Date())).toBe(false)
+  })
+
+  it('should return true when now is before cool-down expiry', () => {
+    const state = makeState({ coolDownUntilUtc: '2026-03-01T23:45:00Z' })
+    expect(isCoolDownActive(state, new Date('2026-03-01T23:40:00Z'))).toBe(true)
+  })
+
+  it('should return false when now is past cool-down expiry', () => {
+    const state = makeState({ coolDownUntilUtc: '2026-03-01T23:45:00Z' })
+    expect(isCoolDownActive(state, new Date('2026-03-01T23:50:00Z'))).toBe(false)
+  })
+})
+
+describe('hasWork', () => {
+  it('should return false for empty state', () => {
+    expect(hasWork(makeState(), new Date())).toBe(false)
+  })
+
+  it('should return true when actionable retreat exists', () => {
+    const entry = makeRetreatEntry('2026-03-01', 'Show #1', '2026-03-01T23:00:00Z')
+    const state = makeState({ retreats: [entry] })
+    expect(hasWork(state, new Date('2026-03-01T23:30:00Z'))).toBe(true)
+  })
+
+  it('should return true when cool-down is active', () => {
+    const state = makeState({ coolDownUntilUtc: '2026-03-01T23:45:00Z' })
+    expect(hasWork(state, new Date('2026-03-01T23:40:00Z'))).toBe(true)
+  })
+})
+
+describe('markRetreatImported', () => {
+  it('should set status to imported with hash and timestamp', () => {
+    const entry = makeRetreatEntry('2026-03-01', 'Show #1', '2026-03-01T23:00:00Z')
+    const state = makeState({ retreats: [entry] })
+    const now = new Date('2026-03-01T23:30:00Z')
+    const updated = markRetreatImported(state, '2026-03-01T23:00:00Z', 'abc123', now)
+
+    expect(updated.retreats[0].status).toBe('imported')
+    expect(updated.retreats[0].sourceHash).toBe('abc123')
+    expect(updated.retreats[0].lastImportedUtc).toBe(now.toISOString())
+  })
+
+  it('should set cool-down to now + 15 minutes', () => {
+    const entry = makeRetreatEntry('2026-03-01', 'Show #1', '2026-03-01T23:00:00Z')
+    const state = makeState({ retreats: [entry] })
+    const now = new Date('2026-03-01T23:30:00Z')
+    const updated = markRetreatImported(state, '2026-03-01T23:00:00Z', 'abc123', now)
+
+    const expectedCoolDown = new Date(now.getTime() + COOL_DOWN_MINUTES * 60_000).toISOString()
+    expect(updated.coolDownUntilUtc).toBe(expectedCoolDown)
+  })
+
+  it('should not modify other retreats', () => {
+    const entry1 = makeRetreatEntry('2026-03-01', 'Show #1 (Regional A)', '2026-03-01T20:00:00Z')
+    const entry2 = makeRetreatEntry('2026-03-01', 'Show #1 (Final)', '2026-03-02T01:00:00Z')
+    const state = makeState({ retreats: [entry1, entry2] })
+    const updated = markRetreatImported(state, '2026-03-01T20:00:00Z', 'abc', new Date())
+
+    expect(updated.retreats[0].status).toBe('imported')
+    expect(updated.retreats[1].status).toBe('pending')
+  })
+})
+
+describe('markRetreatFailed', () => {
+  it('should set status to failed', () => {
+    const entry = makeRetreatEntry('2026-03-01', 'Show #1', '2026-03-01T23:00:00Z')
+    const state = makeState({ retreats: [entry] })
+    const updated = markRetreatFailed(state, '2026-03-01T23:00:00Z')
+
+    expect(updated.retreats[0].status).toBe('failed')
+  })
+})
+
+describe('addOrUpdateRetreat', () => {
+  it('should add a new retreat entry', () => {
+    const state = makeState()
+    const entry = makeRetreatEntry('2026-03-01', 'Show #1', '2026-03-01T23:00:00Z')
+    const updated = addOrUpdateRetreat(state, entry)
+
+    expect(updated.retreats).toHaveLength(1)
+    expect(updated.retreats[0].eventName).toBe('Show #1')
+  })
+
+  it('should update a pending retreat with the same date and retreatUtc', () => {
+    const entry = makeRetreatEntry('2026-03-01', 'Show #1', '2026-03-01T23:00:00Z')
+    const state = makeState({ retreats: [entry] })
+    const updated = addOrUpdateRetreat(state, {
+      ...entry,
+      eventName: 'Show #1 (Delayed)',
+      retreatUtc: '2026-03-01T23:00:00Z',
+      windowCloseUtc: '2026-03-02T01:30:00Z',
+    })
+
+    expect(updated.retreats).toHaveLength(1)
+    expect(updated.retreats[0].eventName).toBe('Show #1 (Delayed)')
+  })
+
+  it('should not overwrite an imported retreat', () => {
+    const entry = {
+      ...makeRetreatEntry('2026-03-01', 'Show #1', '2026-03-01T23:00:00Z'),
+      status: 'imported' as const,
+      sourceHash: 'abc',
+      lastImportedUtc: '2026-03-01T23:30:00Z',
+    }
+    const state = makeState({ retreats: [entry] })
+    const updated = addOrUpdateRetreat(state, makeRetreatEntry('2026-03-01', 'Show #1 NEW', '2026-03-01T23:00:00Z'))
+
+    expect(updated.retreats[0].eventName).toBe('Show #1')
+    expect(updated.retreats[0].status).toBe('imported')
+  })
+
+  it('should add a second retreat for the same date with different retreatUtc (split show)', () => {
+    const entry1 = makeRetreatEntry('2026-03-01', 'Show #1 (Regional A)', '2026-03-01T20:00:00Z')
+    const state = makeState({ retreats: [entry1] })
+    const entry2 = makeRetreatEntry('2026-03-01', 'Show #1 (Final)', '2026-03-02T01:00:00Z')
+    const updated = addOrUpdateRetreat(state, entry2)
+
+    expect(updated.retreats).toHaveLength(2)
+  })
+})
+
+describe('makeRetreatEntry', () => {
+  it('should compute windowCloseUtc as retreat time + 2 hours', () => {
+    const entry = makeRetreatEntry('2026-03-01', 'Show #1', '2026-03-01T23:00:00Z')
+    expect(entry.windowCloseUtc).toBe('2026-03-02T01:00:00.000Z')
+    expect(entry.status).toBe('pending')
+    expect(entry.sourceHash).toBeNull()
+    expect(entry.lastImportedUtc).toBeNull()
+  })
+})

--- a/src/pipeline/pollState.ts
+++ b/src/pipeline/pollState.ts
@@ -1,0 +1,155 @@
+import { readFileSync, writeFileSync } from 'node:fs'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type RetreatStatus = 'pending' | 'imported' | 'failed'
+
+type RetreatEntry = {
+  date: string
+  eventName: string
+  retreatUtc: string
+  windowCloseUtc: string
+  status: RetreatStatus
+  sourceHash: string | null
+  lastImportedUtc: string | null
+}
+
+type PollState = {
+  season: number
+  retreats: Array<RetreatEntry>
+  coolDownUntilUtc: string | null
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const WINDOW_HOURS = 2
+const COOL_DOWN_MINUTES = 15
+
+// ---------------------------------------------------------------------------
+// Read / Write
+// ---------------------------------------------------------------------------
+
+function readPollState(filePath: string): PollState {
+  const raw = readFileSync(filePath, 'utf-8')
+  return JSON.parse(raw) as PollState
+}
+
+function writePollState(filePath: string, state: PollState): void {
+  writeFileSync(filePath, JSON.stringify(state, null, 2) + '\n', 'utf-8')
+}
+
+// ---------------------------------------------------------------------------
+// Query helpers
+// ---------------------------------------------------------------------------
+
+function findActionableRetreats(state: PollState, now: Date): Array<RetreatEntry> {
+  const nowMs = now.getTime()
+  return state.retreats.filter((r) => {
+    if (r.status !== 'pending') return false
+    const retreatMs = new Date(r.retreatUtc).getTime()
+    const closeMs = new Date(r.windowCloseUtc).getTime()
+    return nowMs >= retreatMs && nowMs < closeMs
+  })
+}
+
+function isCoolDownActive(state: PollState, now: Date): boolean {
+  if (!state.coolDownUntilUtc) return false
+  return now.getTime() < new Date(state.coolDownUntilUtc).getTime()
+}
+
+function hasWork(state: PollState, now: Date): boolean {
+  return findActionableRetreats(state, now).length > 0 || isCoolDownActive(state, now)
+}
+
+// ---------------------------------------------------------------------------
+// Mutation helpers (return new state — no in-place mutation)
+// ---------------------------------------------------------------------------
+
+function markRetreatImported(
+  state: PollState,
+  retreatUtc: string,
+  hash: string,
+  now: Date,
+): PollState {
+  const coolDown = new Date(now.getTime() + COOL_DOWN_MINUTES * 60_000).toISOString()
+  return {
+    ...state,
+    coolDownUntilUtc: coolDown,
+    retreats: state.retreats.map((r) =>
+      r.retreatUtc === retreatUtc
+        ? { ...r, status: 'imported' as const, sourceHash: hash, lastImportedUtc: now.toISOString() }
+        : r,
+    ),
+  }
+}
+
+function markRetreatFailed(state: PollState, retreatUtc: string): PollState {
+  return {
+    ...state,
+    retreats: state.retreats.map((r) =>
+      r.retreatUtc === retreatUtc ? { ...r, status: 'failed' as const } : r,
+    ),
+  }
+}
+
+function addOrUpdateRetreat(state: PollState, entry: RetreatEntry): PollState {
+  const idx = state.retreats.findIndex(
+    (r) => r.date === entry.date && r.retreatUtc === entry.retreatUtc,
+  )
+  if (idx === -1) {
+    return { ...state, retreats: [...state.retreats, entry] }
+  }
+  // Only update if the existing entry is still pending
+  const existing = state.retreats[idx]
+  if (existing.status !== 'pending') return state
+  return {
+    ...state,
+    retreats: state.retreats.map((r, i) => (i === idx ? { ...r, ...entry } : r)),
+  }
+}
+
+function makeRetreatEntry(
+  date: string,
+  eventName: string,
+  retreatUtc: string,
+): RetreatEntry {
+  const closeMs = new Date(retreatUtc).getTime() + WINDOW_HOURS * 3_600_000
+  return {
+    date,
+    eventName,
+    retreatUtc,
+    windowCloseUtc: new Date(closeMs).toISOString(),
+    status: 'pending',
+    sourceHash: null,
+    lastImportedUtc: null,
+  }
+}
+
+function emptyPollState(season: number): PollState {
+  return { season, retreats: [], coolDownUntilUtc: null }
+}
+
+// ---------------------------------------------------------------------------
+// Exports
+// ---------------------------------------------------------------------------
+
+export {
+  readPollState,
+  writePollState,
+  findActionableRetreats,
+  isCoolDownActive,
+  hasWork,
+  markRetreatImported,
+  markRetreatFailed,
+  addOrUpdateRetreat,
+  makeRetreatEntry,
+  emptyPollState,
+  WINDOW_HOURS,
+  COOL_DOWN_MINUTES,
+}
+
+export type { RetreatStatus, RetreatEntry, PollState }

--- a/src/pipeline/reportIssue.ts
+++ b/src/pipeline/reportIssue.ts
@@ -1,0 +1,62 @@
+import { execSync } from 'node:child_process'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type IssueFailure = {
+  failureType: string
+  eventName: string
+  date: string
+  sourceUrl: string | null
+  gate: string | null
+  errors: Array<string>
+  suggestedAction: string
+}
+
+// ---------------------------------------------------------------------------
+// Functions
+// ---------------------------------------------------------------------------
+
+function formatIssueBody(failure: IssueFailure): string {
+  const errorList = failure.errors.map((e) => `- ${e}`).join('\n')
+  return `## What happened
+${failure.failureType}
+
+## Details
+- **Event:** ${failure.eventName}
+- **Date:** ${failure.date}
+- **Source URL:** ${failure.sourceUrl ?? 'N/A'}
+- **Failed gate:** ${failure.gate ?? 'N/A'}
+
+## Errors
+${errorList}
+
+## Action needed
+${failure.suggestedAction}
+
+---
+*Filed automatically by the score ingestion pipeline.*`
+}
+
+function reportFailure(failure: IssueFailure): void {
+  const title = `[Score Pipeline] ${failure.failureType} — ${failure.eventName} (${failure.date})`
+  const body = formatIssueBody(failure)
+  const labels = ['score-pipeline']
+
+  if (failure.gate === 'validation-failure') labels.push('validation-failure')
+  if (failure.failureType.includes('not posted')) labels.push('missing-scores')
+  if (failure.failureType.includes('ensemble')) labels.push('new-ensemble')
+
+  execSync(
+    `gh issue create --title "${title.replace(/"/g, '\\"')}" --label "${labels.join(',')}" --body "${body.replace(/"/g, '\\"').replace(/\n/g, '\\n')}"`,
+    { stdio: 'inherit' },
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Exports
+// ---------------------------------------------------------------------------
+
+export { formatIssueBody, reportFailure }
+export type { IssueFailure }

--- a/src/pipeline/scrapeSchedule.test.ts
+++ b/src/pipeline/scrapeSchedule.test.ts
@@ -1,0 +1,146 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, it, expect } from 'vitest'
+import {
+  parseCompetitionsPage,
+  parseScheduleRetreats,
+  localTimeToUtc,
+  filterUpcomingEvents,
+} from './scrapeSchedule'
+
+const competitionsHtml = readFileSync(
+  resolve(import.meta.dirname, '../../data/test-fixtures/rmpa-competitions-page.html'),
+  'utf-8',
+)
+const singleRetreatHtml = readFileSync(
+  resolve(import.meta.dirname, '../../data/test-fixtures/schedule-single-retreat.html'),
+  'utf-8',
+)
+const splitRetreatHtml = readFileSync(
+  resolve(import.meta.dirname, '../../data/test-fixtures/schedule-split-retreat.html'),
+  'utf-8',
+)
+
+describe('parseCompetitionsPage', () => {
+  const events = parseCompetitionsPage(competitionsHtml)
+
+  it('should parse multiple events', () => {
+    expect(events.length).toBeGreaterThanOrEqual(7)
+  })
+
+  it('should extract dates in YYYY-MM-DD format', () => {
+    expect(events[0].date).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+    expect(events[0].date).toBe('2026-02-14')
+  })
+
+  it('should extract venue names', () => {
+    expect(events[0].eventName).toBe('Monarch HS')
+  })
+
+  it('should extract schedule URLs', () => {
+    expect(events[0].scheduleUrl).toContain('schedules.competitionsuite.com')
+    expect(events[0].scheduleUrl).toContain('_standard.htm')
+  })
+
+  it('should parse the full 2026 season (7 events)', () => {
+    const dates = events.map((e) => e.date)
+    expect(dates).toContain('2026-02-14')
+    expect(dates).toContain('2026-02-21')
+    expect(dates).toContain('2026-02-28')
+    expect(dates).toContain('2026-03-07')
+    expect(dates).toContain('2026-03-21')
+    expect(dates).toContain('2026-03-28')
+    expect(dates).toContain('2026-04-04')
+  })
+})
+
+describe('parseScheduleRetreats — single retreat', () => {
+  const retreats = parseScheduleRetreats(singleRetreatHtml)
+
+  it('should find one retreat', () => {
+    expect(retreats).toHaveLength(1)
+  })
+
+  it('should extract the retreat label', () => {
+    expect(retreats[0].label).toBe('Retreat/Critique')
+  })
+
+  it('should extract the local time', () => {
+    expect(retreats[0].localTime).toBe('5:28 PM')
+  })
+
+  it('should mark the single retreat as final', () => {
+    expect(retreats[0].isFinal).toBe(true)
+  })
+})
+
+describe('parseScheduleRetreats — split retreat', () => {
+  const retreats = parseScheduleRetreats(splitRetreatHtml)
+
+  it('should find two retreats', () => {
+    expect(retreats).toHaveLength(2)
+  })
+
+  it('should extract Regional A retreat first', () => {
+    expect(retreats[0].label).toBe('Regional A Retreat/Critique')
+    expect(retreats[0].localTime).toBe('1:45 PM')
+    expect(retreats[0].isFinal).toBe(false)
+  })
+
+  it('should extract final retreat second', () => {
+    expect(retreats[1].label).toBe('Retreat/Critique')
+    expect(retreats[1].localTime).toBe('6:55 PM')
+    expect(retreats[1].isFinal).toBe(true)
+  })
+})
+
+describe('localTimeToUtc', () => {
+  it('should convert MST time correctly (February — UTC-7)', () => {
+    const utc = localTimeToUtc('2026-02-14', '5:28 PM')
+    // 5:28 PM MST = 00:28 UTC next day
+    expect(utc).toBe('2026-02-15T00:28:00.000Z')
+  })
+
+  it('should convert MDT time correctly (April — UTC-6)', () => {
+    const utc = localTimeToUtc('2026-04-04', '8:07 PM')
+    // 8:07 PM MDT = 02:07 UTC next day
+    expect(utc).toBe('2026-04-05T02:07:00.000Z')
+  })
+
+  it('should handle noon correctly', () => {
+    const utc = localTimeToUtc('2026-02-28', '12:45 PM')
+    // 12:45 PM MST = 19:45 UTC same day
+    expect(utc).toBe('2026-02-28T19:45:00.000Z')
+  })
+
+  it('should handle morning times', () => {
+    const utc = localTimeToUtc('2026-03-07', '9:00 AM')
+    // March 7 is before DST (2nd Sunday = Mar 8 in 2026), so MST (UTC-7)
+    // 9:00 AM MST = 16:00 UTC
+    expect(utc).toBe('2026-03-07T16:00:00.000Z')
+  })
+})
+
+describe('filterUpcomingEvents', () => {
+  const events = parseCompetitionsPage(competitionsHtml)
+
+  it('should return events within the window', () => {
+    // Thursday before the first show (Feb 14)
+    const now = new Date('2026-02-12T21:00:00Z') // Thu 2 PM MST
+    const upcoming = filterUpcomingEvents(events, now, 3)
+    expect(upcoming.length).toBeGreaterThanOrEqual(1)
+    expect(upcoming[0].date).toBe('2026-02-14')
+  })
+
+  it('should return empty when no events in window', () => {
+    const now = new Date('2026-01-01T21:00:00Z')
+    const upcoming = filterUpcomingEvents(events, now, 3)
+    expect(upcoming).toHaveLength(0)
+  })
+
+  it('should include today if event is today', () => {
+    const now = new Date('2026-02-14T19:00:00Z') // Feb 14 noon MST
+    const upcoming = filterUpcomingEvents(events, now, 3)
+    expect(upcoming.some((e) => e.date === '2026-02-14')).toBe(true)
+  })
+})

--- a/src/pipeline/scrapeSchedule.ts
+++ b/src/pipeline/scrapeSchedule.ts
@@ -1,0 +1,192 @@
+import { load } from 'cheerio'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type RetreatInfo = {
+  label: string
+  localTime: string
+  isFinal: boolean
+}
+
+type CompetitionEvent = {
+  date: string
+  eventName: string
+  scheduleUrl: string | null
+}
+
+// ---------------------------------------------------------------------------
+// Competitions page parser
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse `rmpa.org/competitions` to extract event dates, names, and schedule links.
+ *
+ * Structure: each event is a pair of `<div class="row">` blocks.
+ * The first contains `<small><em>MM/DD/YY Day</em></small>` and an `<a>` with the venue.
+ * The second contains resource links including "Schedule" pointing to competitionsuite.
+ */
+function parseCompetitionsPage(html: string): Array<CompetitionEvent> {
+  const $ = load(html)
+  const events: Array<CompetitionEvent> = []
+
+  // Each event has a date in a <small><em> and a venue in a <a> with class comp-*
+  $('small em').each((_i, em) => {
+    const dateText = $(em).text().trim() // e.g. "02/14/26 Sat"
+    if (!/^\d{2}\/\d{2}\/\d{2}\s+\w+/.test(dateText)) return
+
+    // Parse the date
+    const date = parseShortDate(dateText)
+
+    // The venue link is in the same parent <p> or the next element
+    const parentP = $(em).closest('p')
+    const venueLink = parentP.find('a span.larger')
+    const eventName = venueLink.text().trim() || 'Unknown'
+
+    // Find the schedule link — it's in a sibling row after this one
+    const eventRow = parentP.closest('.row')
+    const nextRow = eventRow.next('.row')
+    const scheduleLink = nextRow.find('a[href*="competitionsuite.com"][href*="_standard"]')
+    const scheduleUrl = scheduleLink.attr('href') || null
+
+    events.push({ date, eventName, scheduleUrl })
+  })
+
+  return events
+}
+
+function parseShortDate(text: string): string {
+  // "02/14/26 Sat" → "2026-02-14"
+  const match = text.match(/(\d{2})\/(\d{2})\/(\d{2})/)
+  if (!match) return ''
+  const [, mm, dd, yy] = match
+  const year = parseInt(yy, 10) + 2000
+  return `${year}-${mm}-${dd}`
+}
+
+// ---------------------------------------------------------------------------
+// Schedule page parser
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse a CompetitionSuite schedule page to find retreat entries.
+ *
+ * Retreat rows use class `schedule-row--custom` and contain text matching
+ * "Retreat" or "Full Retreat". The time is in `schedule-row__time`.
+ */
+function parseScheduleRetreats(html: string): Array<RetreatInfo> {
+  const $ = load(html)
+  const retreats: Array<RetreatInfo> = []
+
+  $('.schedule-row--custom').each((_i, row) => {
+    const label = $(row).find('.schedule-row__custom').text().trim()
+    if (!/retreat/i.test(label)) return
+
+    const timeText = $(row).find('.schedule-row__time').text().trim()
+    retreats.push({
+      label,
+      localTime: timeText,
+      isFinal: false, // set below
+    })
+  })
+
+  // Mark the last retreat as final
+  if (retreats.length > 0) {
+    retreats[retreats.length - 1].isFinal = true
+  }
+
+  // If no retreats found, try to find the last performance time as fallback
+  if (retreats.length === 0) {
+    const allTimes = $('.schedule-row__time')
+    if (allTimes.length > 0) {
+      const lastTime = allTimes.last().text().trim()
+      retreats.push({
+        label: 'Estimated (last performance + 60 min)',
+        localTime: lastTime,
+        isFinal: true,
+      })
+    }
+  }
+
+  return retreats
+}
+
+/**
+ * Convert a local time string (e.g. "5:28 PM") on a given date to a UTC ISO string.
+ * Uses America/Denver timezone.
+ */
+function localTimeToUtc(date: string, localTime: string): string {
+  // Parse "5:28 PM" or "12:45 PM"
+  const match = localTime.match(/(\d{1,2}):(\d{2})\s*(AM|PM)/i)
+  if (!match) return ''
+
+  let hours = parseInt(match[1], 10)
+  const minutes = parseInt(match[2], 10)
+  const ampm = match[3].toUpperCase()
+
+  if (ampm === 'PM' && hours !== 12) hours += 12
+  if (ampm === 'AM' && hours === 12) hours = 0
+
+  // Use Intl to find the UTC offset for this specific date/time in Denver
+  const formatter = new Intl.DateTimeFormat('en-US', {
+    timeZone: 'America/Denver',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false,
+  })
+
+  // Create a Date assuming UTC, then adjust
+  // Simpler approach: construct the date with a known offset calculation
+  // Use a temporary date to find Denver's offset on this date
+  const utcEpoch = Date.UTC(
+    parseInt(date.slice(0, 4)),
+    parseInt(date.slice(5, 7)) - 1,
+    parseInt(date.slice(8, 10)),
+    hours,
+    minutes,
+  )
+
+  // Get what Denver would display for this UTC time
+  const parts = formatter.formatToParts(new Date(utcEpoch))
+  const denverHour = parseInt(parts.find((p) => p.type === 'hour')?.value ?? '0', 10)
+
+  // The difference between the hour we wanted and the hour Denver shows is the offset
+  const hourDiff = hours - denverHour
+  // Adjust: if we wanted 17:00 Denver but UTC shows 17:00 as 11:00 Denver, offset = +6
+  const adjustedUtc = utcEpoch + hourDiff * 3_600_000
+
+  return new Date(adjustedUtc).toISOString()
+}
+
+/**
+ * Filter competition events to those within a window of days from now.
+ */
+function filterUpcomingEvents(
+  events: Array<CompetitionEvent>,
+  now: Date,
+  windowDays: number,
+): Array<CompetitionEvent> {
+  const nowMs = now.getTime()
+  const windowMs = windowDays * 24 * 3_600_000
+  return events.filter((e) => {
+    const eventMs = new Date(e.date + 'T00:00:00Z').getTime()
+    return eventMs >= nowMs - 24 * 3_600_000 && eventMs <= nowMs + windowMs
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Exports
+// ---------------------------------------------------------------------------
+
+export {
+  parseCompetitionsPage,
+  parseScheduleRetreats,
+  localTimeToUtc,
+  filterUpcomingEvents,
+}
+export type { RetreatInfo, CompetitionEvent }

--- a/src/pipeline/scrapeScores.test.ts
+++ b/src/pipeline/scrapeScores.test.ts
@@ -1,0 +1,69 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, it, expect } from 'vitest'
+import { parseScorePage, filterByYear } from './scrapeScores'
+
+const html = readFileSync(
+  resolve(import.meta.dirname, '../../data/test-fixtures/rmpa-scores-page.html'),
+  'utf-8',
+)
+
+describe('parseScorePage', () => {
+  const entries = parseScorePage(html)
+
+  it('should parse entries from multiple years', () => {
+    const years = new Set(entries.map((e) => e.year))
+    expect(years.size).toBeGreaterThan(5)
+    expect(years.has(2025)).toBe(true)
+    expect(years.has(2024)).toBe(true)
+    expect(years.has(2015)).toBe(true)
+  })
+
+  it('should parse all 8 entries for 2025', () => {
+    const y2025 = entries.filter((e) => e.year === 2025)
+    expect(y2025).toHaveLength(8)
+  })
+
+  it('should extract correct recap URLs', () => {
+    const y2025 = entries.filter((e) => e.year === 2025)
+    expect(y2025[0].recapUrl).toContain('recaps.competitionsuite.com')
+    expect(y2025[0].recapUrl).toMatch(/\.htm$/)
+  })
+
+  it('should extract date text from link', () => {
+    const y2025 = entries.filter((e) => e.year === 2025)
+    expect(y2025[0].date).toBe('March, 29 2025')
+  })
+
+  it('should extract event name from adjacent text', () => {
+    const y2025 = entries.filter((e) => e.year === 2025)
+    expect(y2025[0].eventName).toBe('RMPA State Championships')
+    const show1 = y2025.find((e) => e.date.includes('February, 8'))
+    expect(show1?.eventName).toBe('Regular Season Show #1')
+  })
+
+  it('should skip non-competitionsuite links (pre-2013 PDFs)', () => {
+    // Entries before 2013 link to PDFs, not competitionsuite
+    const allUrls = entries.map((e) => e.recapUrl)
+    expect(allUrls.every((url) => url.includes('competitionsuite.com'))).toBe(true)
+  })
+
+  it('should parse 7 entries for 2024', () => {
+    const y2024 = entries.filter((e) => e.year === 2024)
+    expect(y2024).toHaveLength(7)
+  })
+})
+
+describe('filterByYear', () => {
+  const entries = parseScorePage(html)
+
+  it('should return only entries for the specified year', () => {
+    const y2025 = filterByYear(entries, 2025)
+    expect(y2025.every((e) => e.year === 2025)).toBe(true)
+    expect(y2025).toHaveLength(8)
+  })
+
+  it('should return empty array for a year with no entries', () => {
+    expect(filterByYear(entries, 9999)).toEqual([])
+  })
+})

--- a/src/pipeline/scrapeScores.ts
+++ b/src/pipeline/scrapeScores.ts
@@ -1,0 +1,68 @@
+import { load } from 'cheerio'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type RecapEntry = {
+  date: string
+  eventName: string
+  recapUrl: string
+  year: number
+}
+
+// ---------------------------------------------------------------------------
+// Functions
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse the rmpa.org/scores HTML page and extract all recap entries.
+ *
+ * Structure: each year is a `<ul class="list-group">` containing
+ *   - a header `<li class="list-group-item active">` with the year text
+ *   - entry `<li class="list-group-item">` with an `<a>` (date + URL) and
+ *     adjacent text (event name)
+ */
+function parseScorePage(html: string): Array<RecapEntry> {
+  const $ = load(html)
+  const entries: Array<RecapEntry> = []
+
+  $('ul.list-group').each((_i, ul) => {
+    const yearText = $(ul).find('li.list-group-item.active').text().trim()
+    const year = parseInt(yearText, 10)
+    if (isNaN(year)) return
+
+    $(ul).find('li.list-group-item:not(.active)').each((_j, li) => {
+      const anchor = $(li).find('a')
+      if (anchor.length === 0) return
+
+      const href = anchor.attr('href')
+      if (!href || !href.includes('competitionsuite.com')) return
+
+      const dateText = anchor.text().trim()
+      // Event name is the text content of the <li> after the <a>
+      const fullText = $(li).text().trim()
+      const eventName = fullText.replace(dateText, '').trim()
+
+      entries.push({
+        date: dateText,
+        eventName,
+        recapUrl: href,
+        year,
+      })
+    })
+  })
+
+  return entries
+}
+
+function filterByYear(entries: Array<RecapEntry>, year: number): Array<RecapEntry> {
+  return entries.filter((e) => e.year === year)
+}
+
+// ---------------------------------------------------------------------------
+// Exports
+// ---------------------------------------------------------------------------
+
+export { parseScorePage, filterByYear }
+export type { RecapEntry }

--- a/src/pipeline/validate.test.ts
+++ b/src/pipeline/validate.test.ts
@@ -1,0 +1,154 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, it, expect } from 'vitest'
+import {
+  validateShowData,
+  validateSchema,
+  validateScoreRanges,
+  validateCaptionStructure,
+  validateDataConsistency,
+  validateDeduplication,
+} from './validate'
+import { parseRecapHtml } from '../parser'
+import type { ShowData, SeasonMetadata, EnsembleScore } from '../types'
+
+// Load a real show from test data
+function loadShow(year: number, filename: string): ShowData {
+  const html = readFileSync(
+    resolve(import.meta.dirname, `../../data/scores/${year}/${filename}`),
+    'utf-8',
+  )
+  return parseRecapHtml(html, year)
+}
+
+const show2025 = loadShow(2025, '2025-03-29_RMPA_State_Championships.html')
+
+describe('validateShowData — real 2025 show data', () => {
+  it('should pass all gates on valid parsed data', () => {
+    const result = validateShowData(show2025, 2025)
+    for (const gate of result.gates) {
+      if (!gate.passed) {
+        console.log(`Gate "${gate.name}" failed:`, gate.errors)
+      }
+    }
+    expect(result.passed).toBe(true)
+  })
+})
+
+describe('validateSchema', () => {
+  it('should pass for valid show data', () => {
+    expect(validateSchema(show2025).passed).toBe(true)
+  })
+
+  it('should fail when metadata.id is missing', () => {
+    const bad = { ...show2025, metadata: { ...show2025.metadata, id: '' } }
+    const result = validateSchema(bad)
+    expect(result.passed).toBe(false)
+    expect(result.errors.some((e) => e.includes('id'))).toBe(true)
+  })
+
+  it('should fail when ensemble name is missing', () => {
+    const badEnsemble: EnsembleScore = {
+      ensembleName: '',
+      location: '',
+      captions: [],
+      subTotal: 0,
+      penalty: 0,
+      total: 0,
+      rank: 1,
+    }
+    const bad: ShowData = {
+      ...show2025,
+      classes: [{ classDef: show2025.classes[0].classDef, ensembles: [badEnsemble] }],
+    }
+    const result = validateSchema(bad)
+    expect(result.passed).toBe(false)
+  })
+})
+
+describe('validateScoreRanges', () => {
+  it('should pass for valid show data', () => {
+    expect(validateScoreRanges(show2025).passed).toBe(true)
+  })
+
+  it('should fail when total is out of range', () => {
+    const badEns: EnsembleScore = {
+      ...show2025.classes[0].ensembles[0],
+      total: 150,
+    }
+    const bad: ShowData = {
+      ...show2025,
+      classes: [{ classDef: show2025.classes[0].classDef, ensembles: [badEns] }],
+    }
+    expect(validateScoreRanges(bad).passed).toBe(false)
+  })
+
+  it('should fail when penalty is negative', () => {
+    const badEns: EnsembleScore = {
+      ...show2025.classes[0].ensembles[0],
+      penalty: -1,
+    }
+    const bad: ShowData = {
+      ...show2025,
+      classes: [{ classDef: show2025.classes[0].classDef, ensembles: [badEns] }],
+    }
+    expect(validateScoreRanges(bad).passed).toBe(false)
+  })
+
+  it('should fail when ranks are not sequential', () => {
+    const ensembles = show2025.classes[0].ensembles.map((e, i) => ({
+      ...e,
+      rank: i === 0 ? 5 : e.rank, // break sequential order
+    }))
+    const bad: ShowData = {
+      ...show2025,
+      classes: [{ classDef: show2025.classes[0].classDef, ensembles }],
+    }
+    expect(validateScoreRanges(bad).passed).toBe(false)
+  })
+})
+
+describe('validateCaptionStructure', () => {
+  it('should pass for valid 2025 data', () => {
+    expect(validateCaptionStructure(show2025, 2025).passed).toBe(true)
+  })
+})
+
+describe('validateDataConsistency', () => {
+  it('should pass for valid show data (caption sums match totals)', () => {
+    expect(validateDataConsistency(show2025).passed).toBe(true)
+  })
+
+  it('should fail when caption sum does not match subTotal', () => {
+    const cls = show2025.classes[0]
+    const badEns: EnsembleScore = {
+      ...cls.ensembles[0],
+      subTotal: 999, // impossible
+    }
+    const bad: ShowData = {
+      ...show2025,
+      classes: [{ classDef: cls.classDef, ensembles: [badEns] }],
+    }
+    expect(validateDataConsistency(bad).passed).toBe(false)
+  })
+})
+
+describe('validateDeduplication', () => {
+  it('should pass when no date collision', () => {
+    const season: SeasonMetadata = {
+      year: 2025,
+      shows: [{ id: 'other-show', eventName: 'Other', date: 'January 1', round: '' }],
+      classes: [],
+    }
+    expect(validateDeduplication(show2025, season).passed).toBe(true)
+  })
+
+  it('should fail when date collides with a different show id', () => {
+    const season: SeasonMetadata = {
+      year: 2025,
+      shows: [{ id: 'different-id', eventName: 'Same Date Show', date: show2025.metadata.date, round: '' }],
+      classes: [],
+    }
+    expect(validateDeduplication(show2025, season).passed).toBe(false)
+  })
+})

--- a/src/pipeline/validate.ts
+++ b/src/pipeline/validate.ts
@@ -1,0 +1,212 @@
+import type { ShowData, SeasonMetadata } from '../types'
+import { getMarchingEra, CONCERT_SCHEMA } from '../scoring'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type GateResult = {
+  name: string
+  passed: boolean
+  errors: Array<string>
+  warnings: Array<string>
+}
+
+type ValidationResult = {
+  passed: boolean
+  gates: Array<GateResult>
+}
+
+// ---------------------------------------------------------------------------
+// Gate 1: Schema Validation
+// ---------------------------------------------------------------------------
+
+function validateSchema(showData: ShowData): GateResult {
+  const errors: Array<string> = []
+  const { metadata, classes } = showData
+
+  if (!metadata.id) errors.push('metadata.id is missing')
+  if (!metadata.eventName) errors.push('metadata.eventName is missing')
+  if (!metadata.date) errors.push('metadata.date is missing')
+  if (typeof metadata.year !== 'number') errors.push('metadata.year is not a number')
+  if (!Array.isArray(classes)) errors.push('classes is not an array')
+
+  for (const cls of classes) {
+    if (!cls.classDef?.id) errors.push(`class missing classDef.id`)
+    if (!cls.classDef?.name) errors.push(`class missing classDef.name`)
+    if (!Array.isArray(cls.ensembles)) errors.push(`class ${cls.classDef?.name} ensembles is not an array`)
+
+    for (const ens of cls.ensembles) {
+      if (!ens.ensembleName) errors.push('ensemble missing ensembleName')
+      if (typeof ens.total !== 'number') errors.push(`${ens.ensembleName}: total is not a number`)
+      if (typeof ens.rank !== 'number') errors.push(`${ens.ensembleName}: rank is not a number`)
+    }
+  }
+
+  return { name: 'Schema Validation', passed: errors.length === 0, errors, warnings: [] }
+}
+
+// ---------------------------------------------------------------------------
+// Gate 2: Score Range Checks
+// ---------------------------------------------------------------------------
+
+function validateScoreRanges(showData: ShowData): GateResult {
+  const errors: Array<string> = []
+
+  for (const cls of showData.classes) {
+    for (const ens of cls.ensembles) {
+      if (isNaN(ens.total)) errors.push(`${ens.ensembleName}: total is NaN`)
+      if (ens.total < 0 || ens.total > 100) errors.push(`${ens.ensembleName}: total ${ens.total} out of range 0-100`)
+      if (ens.penalty < 0) errors.push(`${ens.ensembleName}: penalty ${ens.penalty} is negative`)
+      if (ens.rank < 1) errors.push(`${ens.ensembleName}: rank ${ens.rank} is less than 1`)
+
+      for (const cap of ens.captions) {
+        if (isNaN(cap.captionTotal)) errors.push(`${ens.ensembleName}/${cap.captionName}: captionTotal is NaN`)
+        if (cap.captionTotal < 0) errors.push(`${ens.ensembleName}/${cap.captionName}: captionTotal ${cap.captionTotal} is negative`)
+
+        for (const judge of cap.judges) {
+          for (const sub of judge.subCaptions) {
+            if (isNaN(sub.rawScore)) errors.push(`${ens.ensembleName}/${cap.captionName}/${judge.judgeName}: rawScore is NaN`)
+            if (sub.rawScore < 0 || sub.rawScore > 100) {
+              errors.push(`${ens.ensembleName}/${cap.captionName}/${judge.judgeName}/${sub.key}: rawScore ${sub.rawScore} out of range 0-100`)
+            }
+          }
+        }
+      }
+    }
+
+    // Check ranks are sequential within class
+    const ranks = cls.ensembles.map((e) => e.rank).sort((a, b) => a - b)
+    for (let i = 0; i < ranks.length; i++) {
+      if (ranks[i] !== i + 1) {
+        errors.push(`${cls.classDef.name}: ranks not sequential — expected ${i + 1}, got ${ranks[i]}`)
+        break
+      }
+    }
+  }
+
+  return { name: 'Score Range Checks', passed: errors.length === 0, errors, warnings: [] }
+}
+
+// ---------------------------------------------------------------------------
+// Gate 3: Caption Structure
+// ---------------------------------------------------------------------------
+
+function validateCaptionStructure(showData: ShowData, year: number): GateResult {
+  const errors: Array<string> = []
+
+  for (const cls of showData.classes) {
+    const classType = cls.classDef.classType
+    if (cls.ensembles.length === 0) continue
+
+    const firstEnsemble = cls.ensembles[0]
+    const captionCount = firstEnsemble.captions.length
+
+    if (classType === 'concert' || classType === 'standstill') {
+      if (captionCount !== CONCERT_SCHEMA.captions.length) {
+        errors.push(`${cls.classDef.name}: expected ${CONCERT_SCHEMA.captions.length} captions for ${classType}, got ${captionCount}`)
+      }
+    } else {
+      // marching
+      const era = getMarchingEra(year)
+      if (era) {
+        const expectedCount = 'marchingCaptions' in era
+          ? (era as { marchingCaptions: Array<unknown> }).marchingCaptions.length
+          : era.captions.length
+        if (captionCount !== expectedCount) {
+          errors.push(`${cls.classDef.name}: expected ${expectedCount} captions for ${classType} (year ${year}), got ${captionCount}`)
+        }
+      }
+    }
+  }
+
+  return { name: 'Caption Structure', passed: errors.length === 0, errors, warnings: [] }
+}
+
+// ---------------------------------------------------------------------------
+// Gate 5: Change Detection & Deduplication
+// ---------------------------------------------------------------------------
+
+function validateDeduplication(showData: ShowData, season: SeasonMetadata): GateResult {
+  const errors: Array<string> = []
+
+  // Check for date + venue collision with existing shows
+  const showDate = showData.metadata.date
+  for (const existing of season.shows) {
+    if (existing.date === showDate && existing.id !== showData.metadata.id) {
+      errors.push(`Possible duplicate: show date "${showDate}" matches existing show "${existing.id}"`)
+    }
+  }
+
+  return { name: 'Change Detection', passed: errors.length === 0, errors, warnings: [] }
+}
+
+// ---------------------------------------------------------------------------
+// Gate 7: Data Consistency
+// ---------------------------------------------------------------------------
+
+function validateDataConsistency(showData: ShowData): GateResult {
+  const errors: Array<string> = []
+  const tolerance = 0.5 // allow rounding drift from CompetitionSuite's display precision
+
+  for (const cls of showData.classes) {
+    for (const ens of cls.ensembles) {
+      // The parser may not always populate subTotal separately from total.
+      // Use subTotal if available, otherwise derive from total + penalty.
+      const effectiveSubTotal = ens.subTotal > 0 ? ens.subTotal : ens.total + ens.penalty
+
+      // Caption totals should sum to the effective subTotal
+      const captionSum = ens.captions.reduce((sum, c) => sum + c.captionTotal, 0)
+      if (Math.abs(captionSum - effectiveSubTotal) > tolerance) {
+        errors.push(`${ens.ensembleName}: caption sum ${captionSum.toFixed(3)} != subTotal ${effectiveSubTotal} (diff ${Math.abs(captionSum - effectiveSubTotal).toFixed(3)})`)
+      }
+
+      // effectiveSubTotal - penalty should equal total
+      if (ens.subTotal > 0) {
+        const expectedTotal = ens.subTotal - ens.penalty
+        if (Math.abs(expectedTotal - ens.total) > tolerance) {
+          errors.push(`${ens.ensembleName}: subTotal ${ens.subTotal} - penalty ${ens.penalty} = ${expectedTotal.toFixed(3)} != total ${ens.total}`)
+        }
+      }
+    }
+  }
+
+  return { name: 'Data Consistency', passed: errors.length === 0, errors, warnings: [] }
+}
+
+// ---------------------------------------------------------------------------
+// Main validation function
+// ---------------------------------------------------------------------------
+
+function validateShowData(showData: ShowData, year: number, season?: SeasonMetadata): ValidationResult {
+  const gates: Array<GateResult> = [
+    validateSchema(showData),
+    validateScoreRanges(showData),
+    validateCaptionStructure(showData, year),
+    validateDataConsistency(showData),
+  ]
+
+  if (season) {
+    gates.push(validateDeduplication(showData, season))
+  }
+
+  return {
+    passed: gates.every((g) => g.passed),
+    gates,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Exports
+// ---------------------------------------------------------------------------
+
+export {
+  validateShowData,
+  validateSchema,
+  validateScoreRanges,
+  validateCaptionStructure,
+  validateDeduplication,
+  validateDataConsistency,
+}
+
+export type { GateResult, ValidationResult }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -14,6 +14,9 @@ export default defineConfig({
         'src/import.ts',
         'src/data.ts',
         'src/hooks/**',
+        'src/pipeline/cli/**',
+        'src/pipeline/commit.ts',
+        'src/pipeline/reportIssue.ts',
       ],
       thresholds: {
         lines: 80,


### PR DESCRIPTION
## Summary
Implements all core pipeline modules from the [implementation plan](docs/plans/pipeline-implementation-plan.md) Phase 1:

- **Poll State Manager** (`pollState.ts`) — track retreat status, cool-down windows, and import state across cron invocations
- **Content Hasher** (`contentHash.ts`) — SHA-256 hashing for detecting new/changed score recaps
- **Score Page Scraper** (`scrapeScores.ts`) — parse `rmpa.org/scores` to extract recap entry URLs, dates, and event names
- **Schedule Scraper** (`scrapeSchedule.ts`) — parse `rmpa.org/competitions` and CompetitionSuite schedule pages to determine retreat times with DST-aware UTC conversion
- **Validation Module** (`validate.ts`) — 5 gates: schema, score ranges, caption structure, deduplication, data consistency
- **Issue Reporter** (`reportIssue.ts`) — format and file GitHub issues for pipeline failures
- **Auto-Commit** (`commit.ts`) — git commit wrappers with structured commit messages

Test fixtures fetched from live rmpa.org pages (scores page, competitions page, single-retreat schedule, split-retreat schedule).

## Test plan
- [x] 184 tests pass (69 new pipeline tests)
- [x] Coverage thresholds met
- [x] Build succeeds
- [x] Validation tested against real 2025 parsed show data

🤖 Generated with [Claude Code](https://claude.com/claude-code)