### PR TITLE
feat: pipeline Phase 3 — GitHub Actions workflows

### DIFF
--- a/.github/workflows/schedule-watcher.yml
+++ b/.github/workflows/schedule-watcher.yml
@@ -1,0 +1,42 @@
+name: Schedule Watcher
+
+on:
+  schedule:
+    # 2:00 PM MST = 21:00 UTC (early season, before DST)
+    - cron: '0 21 * * 4,5,6'
+    # 2:00 PM MDT = 20:00 UTC (mid-season onward, after DST)
+    - cron: '0 20 * * 4,5,6'
+  workflow_dispatch: {}
+
+jobs:
+  watch:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: '24'
+          cache: npm
+
+      - run: npm ci
+
+      - name: DST guard
+        run: npx tsx src/pipeline/cli/dstGuard.ts --mst-hour 21 --mdt-hour 20
+        if: github.event_name == 'schedule'
+
+      - name: Watch schedules
+        run: npx tsx src/pipeline/cli/watchSchedule.ts
+
+      - name: Commit and push
+        run: |
+          git config user.name "score-pipeline[bot]"
+          git config user.email "score-pipeline[bot]@users.noreply.github.com"
+          git add public/data/poll-state.json
+          git diff --cached --quiet && echo "No changes to commit" && exit 0
+          git commit -m "chore(data): update poll-state with retreat times
+
+          Automated by: score-ingestion-pipeline"
+          git push

--- a/.github/workflows/score-fallback.yml
+++ b/.github/workflows/score-fallback.yml
@@ -1,0 +1,45 @@
+name: Score Fallback
+
+on:
+  schedule:
+    # Mon-Fri noon MST = 19:00 UTC
+    - cron: '0 19 * * 1-5'
+    # Mon-Fri noon MDT = 18:00 UTC
+    - cron: '0 18 * * 1-5'
+  workflow_dispatch: {}
+
+jobs:
+  fallback:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: '24'
+          cache: npm
+
+      - run: npm ci
+
+      - name: DST guard
+        run: npx tsx src/pipeline/cli/dstGuard.ts --mst-hour 19 --mdt-hour 18
+        if: github.event_name == 'schedule'
+
+      - name: Check for new or updated scores
+        run: npx tsx src/pipeline/cli/fallback.ts
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Commit and push
+        run: |
+          git config user.name "score-pipeline[bot]"
+          git config user.email "score-pipeline[bot]@users.noreply.github.com"
+          git add -A public/data/ data/scores/
+          git diff --cached --quiet && echo "No changes to commit" && exit 0
+          git commit -m "chore(data): fallback score check
+
+          Automated by: score-ingestion-pipeline"
+          git push

--- a/.github/workflows/score-poller.yml
+++ b/.github/workflows/score-poller.yml
@@ -1,0 +1,45 @@
+name: Score Poller
+
+on:
+  schedule:
+    # Every 3 minutes, Fri/Sat evening MST window (6 PM-11 PM MT = 01:00-06:00 UTC next day)
+    - cron: '*/3 1-6 * * 0,6'
+    # Every 3 minutes, Fri/Sat evening MDT window (6 PM-11 PM MT = 00:00-05:00 UTC next day)
+    - cron: '*/3 0-5 * * 0,6'
+  workflow_dispatch: {}
+
+jobs:
+  poll:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: '24'
+          cache: npm
+
+      - run: npm ci
+
+      - name: DST guard
+        run: npx tsx src/pipeline/cli/dstGuard.ts --mst-hours 1-6 --mdt-hours 0-5
+        if: github.event_name == 'schedule'
+
+      - name: Poll for scores
+        run: npx tsx src/pipeline/cli/pollScores.ts
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Commit and push
+        run: |
+          git config user.name "score-pipeline[bot]"
+          git config user.email "score-pipeline[bot]@users.noreply.github.com"
+          git add -A public/data/ data/scores/
+          git diff --cached --quiet && echo "No changes to commit" && exit 0
+          git commit -m "chore(data): auto-import scores
+
+          Automated by: score-ingestion-pipeline"
+          git push

--- a/.github/workflows/season-lifecycle.yml
+++ b/.github/workflows/season-lifecycle.yml
@@ -1,0 +1,129 @@
+name: Season Lifecycle
+
+on:
+  schedule:
+    # Pre-season: January 25 at noon MST = 19:00 UTC
+    - cron: '0 19 25 1 *'
+    # Post-season: April 30 at noon MDT = 18:00 UTC
+    - cron: '0 18 30 4 *'
+  workflow_dispatch:
+    inputs:
+      action:
+        description: 'Force action type'
+        required: true
+        type: choice
+        options:
+          - enable
+          - disable
+
+jobs:
+  lifecycle:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Determine action
+        id: action
+        run: |
+          if [ -n "${{ inputs.action }}" ]; then
+            echo "type=${{ inputs.action }}" >> "$GITHUB_OUTPUT"
+          else
+            MONTH=$(date +%-m)
+            if [ "$MONTH" = "1" ]; then
+              echo "type=enable" >> "$GITHUB_OUTPUT"
+            elif [ "$MONTH" = "4" ]; then
+              echo "type=disable" >> "$GITHUB_OUTPUT"
+            else
+              echo "type=none" >> "$GITHUB_OUTPUT"
+            fi
+          fi
+
+      - name: File enable issue
+        if: steps.action.outputs.type == 'enable'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          YEAR=$(date +%Y)
+          gh issue create \
+            --repo "$GITHUB_REPOSITORY" \
+            --title "[Score Pipeline] Enable season workflows for $YEAR" \
+            --label "score-pipeline" \
+            --body "## Action needed
+
+          The RMPA season typically begins in early-to-mid February. Enable the score ingestion workflows so the pipeline is ready before the first competition.
+
+          ### Steps
+
+          1. Go to **Actions** → each workflow listed below → **Enable workflow**
+          2. Create \`public/data/$YEAR/season.json\` with empty show list if it doesn't exist yet
+          3. Initialize \`public/data/poll-state.json\` with \`{ \"season\": $YEAR, \"retreats\": [], \"coolDownUntilUtc\": null }\`
+          4. Verify \`rmpa.org/competitions\` has the new season's events listed
+
+          ### Workflows to enable
+
+          | Workflow | File |
+          |----------|------|
+          | Schedule Watcher | \`schedule-watcher.yml\` |
+          | Score Poller | \`score-poller.yml\` |
+          | Sunday Reconciliation | \`sunday-reconciliation.yml\` |
+          | Score Fallback | \`score-fallback.yml\` |
+
+          ### CLI commands
+
+          \`\`\`bash
+          gh workflow enable schedule-watcher.yml
+          gh workflow enable score-poller.yml
+          gh workflow enable sunday-reconciliation.yml
+          gh workflow enable score-fallback.yml
+          \`\`\`
+
+          ### Verify
+
+          After enabling, check that the next scheduled runs appear on the Actions tab for each workflow.
+
+          ---
+          *Filed automatically by the season lifecycle workflow.*"
+
+      - name: File disable issue
+        if: steps.action.outputs.type == 'disable'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          YEAR=$(date +%Y)
+          gh issue create \
+            --repo "$GITHUB_REPOSITORY" \
+            --title "[Score Pipeline] Disable season workflows — $YEAR season complete" \
+            --label "score-pipeline" \
+            --body "## Action needed
+
+          The RMPA season has ended (finals typically mid-April). Disable the score ingestion workflows to avoid unnecessary cron invocations during the off-season.
+
+          ### Steps
+
+          1. Go to **Actions** → each workflow listed below → **Disable workflow**
+          2. Confirm no pending \`score-pipeline\` issues remain open
+
+          ### Workflows to disable
+
+          | Workflow | File |
+          |----------|------|
+          | Schedule Watcher | \`schedule-watcher.yml\` |
+          | Score Poller | \`score-poller.yml\` |
+          | Sunday Reconciliation | \`sunday-reconciliation.yml\` |
+          | Score Fallback | \`score-fallback.yml\` |
+
+          ### CLI commands
+
+          \`\`\`bash
+          gh workflow disable schedule-watcher.yml
+          gh workflow disable score-poller.yml
+          gh workflow disable sunday-reconciliation.yml
+          gh workflow disable score-fallback.yml
+          \`\`\`
+
+          ### What stays enabled
+
+          The **Season Lifecycle** workflow (\`season-lifecycle.yml\`) stays enabled year-round. It will file another enable issue next January.
+
+          ---
+          *Filed automatically by the season lifecycle workflow.*"

--- a/.github/workflows/sunday-reconciliation.yml
+++ b/.github/workflows/sunday-reconciliation.yml
@@ -1,0 +1,45 @@
+name: Sunday Reconciliation
+
+on:
+  schedule:
+    # Sunday noon MST = 19:00 UTC
+    - cron: '0 19 * * 0'
+    # Sunday noon MDT = 18:00 UTC
+    - cron: '0 18 * * 0'
+  workflow_dispatch: {}
+
+jobs:
+  reconcile:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: '24'
+          cache: npm
+
+      - run: npm ci
+
+      - name: DST guard
+        run: npx tsx src/pipeline/cli/dstGuard.ts --mst-hour 19 --mdt-hour 18
+        if: github.event_name == 'schedule'
+
+      - name: Reconcile weekend scores
+        run: npx tsx src/pipeline/cli/reconcile.ts
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Commit and push
+        run: |
+          git config user.name "score-pipeline[bot]"
+          git config user.email "score-pipeline[bot]@users.noreply.github.com"
+          git add -A public/data/ data/scores/
+          git diff --cached --quiet && echo "No changes to commit" && exit 0
+          git commit -m "chore(data): reconcile weekend scores
+
+          Automated by: score-ingestion-pipeline"
+          git push

--- a/public/data/poll-state.json
+++ b/public/data/poll-state.json
@@ -1,0 +1,5 @@
+{
+  "season": 2026,
+  "retreats": [],
+  "coolDownUntilUtc": null
+}


### PR DESCRIPTION
## Summary
Implements Phase 3 of the [pipeline implementation plan](docs/plans/pipeline-implementation-plan.md) — all 5 GitHub Actions workflow files plus the initial `poll-state.json`.

| Workflow | Cron | Stage | DST handling |
|----------|------|-------|-------------|
| `schedule-watcher.yml` | Thu/Fri/Sat 2 PM MT | 1 | `--mst-hour 21 --mdt-hour 20` |
| `score-poller.yml` | Every 3 min Fri/Sat evenings | 2 | `--mst-hours 1-6 --mdt-hours 0-5` |
| `sunday-reconciliation.yml` | Sun noon MT | 3 | `--mst-hour 19 --mdt-hour 18` |
| `score-fallback.yml` | Mon–Fri noon MT | 4 | `--mst-hour 19 --mdt-hour 18` |
| `season-lifecycle.yml` | Jan 25 + Apr 30 | 5 | Fixed months (Jan=MST, Apr=MDT) |

All workflows:
- Use dual-cron + DST guard pattern (skipped on `workflow_dispatch`)
- Commit as `score-pipeline[bot]`
- Support manual trigger via `workflow_dispatch`
- Season lifecycle supports force enable/disable input

**Important:** Stages 1–4 should be **disabled** after merge until the season starts. Only `season-lifecycle.yml` stays enabled year-round.

Also initializes `public/data/poll-state.json` for the 2026 season.

## Test plan
- [x] All 192 tests pass
- [x] Build succeeds
- [x] YAML validated (proper indentation, correct cron syntax)

🤖 Generated with [Claude Code](https://claude.com/claude-code)