### PR TITLE
feat: automate season lifecycle with PAT-based workflow enable/disable

### DIFF
--- a/.github/workflows/season-lifecycle.yml
+++ b/.github/workflows/season-lifecycle.yml
@@ -20,8 +20,11 @@ jobs:
   lifecycle:
     runs-on: ubuntu-latest
     permissions:
+      contents: write
       issues: write
     steps:
+      - uses: actions/checkout@v4
+
       - name: Determine action
         id: action
         run: |
@@ -38,7 +41,65 @@ jobs:
             fi
           fi
 
-      - name: File enable issue
+      # ---------------------------------------------------------------
+      # ENABLE — create season data, reset poll-state, enable workflows
+      # ---------------------------------------------------------------
+
+      - name: Create season data
+        if: steps.action.outputs.type == 'enable'
+        run: |
+          YEAR=$(date +%Y)
+          SEASON_DIR="public/data/${YEAR}"
+          SEASON_FILE="${SEASON_DIR}/season.json"
+          POLL_STATE="public/data/poll-state.json"
+
+          mkdir -p "$SEASON_DIR"
+
+          # Create season.json if it doesn't exist
+          if [ ! -f "$SEASON_FILE" ]; then
+            echo "{
+            \"year\": ${YEAR},
+            \"shows\": [],
+            \"classes\": []
+          }" > "$SEASON_FILE"
+            echo "Created ${SEASON_FILE}"
+          else
+            echo "${SEASON_FILE} already exists — skipping"
+          fi
+
+          # Reset poll-state.json for the new season
+          echo "{
+            \"season\": ${YEAR},
+            \"retreats\": [],
+            \"coolDownUntilUtc\": null
+          }" > "$POLL_STATE"
+          echo "Reset ${POLL_STATE} for ${YEAR}"
+
+      - name: Commit season data
+        if: steps.action.outputs.type == 'enable'
+        run: |
+          git config user.name "score-pipeline[bot]"
+          git config user.email "score-pipeline[bot]@users.noreply.github.com"
+          git add public/data/
+          git diff --cached --quiet && echo "No data changes to commit" && exit 0
+          YEAR=$(date +%Y)
+          git commit -m "chore(data): initialize ${YEAR} season
+
+          Automated by: season-lifecycle"
+          git push
+
+      - name: Enable season workflows
+        if: steps.action.outputs.type == 'enable'
+        env:
+          GH_TOKEN: ${{ secrets.PIPELINE_PAT }}
+        run: |
+          WORKFLOWS="schedule-watcher.yml score-poller.yml sunday-reconciliation.yml score-fallback.yml"
+          for wf in $WORKFLOWS; do
+            gh workflow enable "$wf"
+            echo "Enabled $wf"
+          done
+
+      - name: File enable summary issue
         if: steps.action.outputs.type == 'enable'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -46,45 +107,43 @@ jobs:
           YEAR=$(date +%Y)
           gh issue create \
             --repo "$GITHUB_REPOSITORY" \
-            --title "[Score Pipeline] Enable season workflows for $YEAR" \
+            --title "[Score Pipeline] ${YEAR} season enabled" \
             --label "score-pipeline" \
-            --body "## Action needed
+            --body "## Season ${YEAR} pipeline enabled
 
-          The RMPA season typically begins in early-to-mid February. Enable the score ingestion workflows so the pipeline is ready before the first competition.
+          The following actions were taken automatically:
 
-          ### Steps
-
-          1. Go to **Actions** → each workflow listed below → **Enable workflow**
-          2. Create \`public/data/$YEAR/season.json\` with empty show list if it doesn't exist yet
-          3. Initialize \`public/data/poll-state.json\` with \`{ \"season\": $YEAR, \"retreats\": [], \"coolDownUntilUtc\": null }\`
-          4. Verify \`rmpa.org/competitions\` has the new season's events listed
-
-          ### Workflows to enable
-
-          | Workflow | File |
-          |----------|------|
-          | Schedule Watcher | \`schedule-watcher.yml\` |
-          | Score Poller | \`score-poller.yml\` |
-          | Sunday Reconciliation | \`sunday-reconciliation.yml\` |
-          | Score Fallback | \`score-fallback.yml\` |
-
-          ### CLI commands
-
-          \`\`\`bash
-          gh workflow enable schedule-watcher.yml
-          gh workflow enable score-poller.yml
-          gh workflow enable sunday-reconciliation.yml
-          gh workflow enable score-fallback.yml
-          \`\`\`
+          - [x] Created \`public/data/${YEAR}/season.json\` (if missing)
+          - [x] Reset \`public/data/poll-state.json\` for ${YEAR}
+          - [x] Enabled \`schedule-watcher.yml\`
+          - [x] Enabled \`score-poller.yml\`
+          - [x] Enabled \`sunday-reconciliation.yml\`
+          - [x] Enabled \`score-fallback.yml\`
 
           ### Verify
 
-          After enabling, check that the next scheduled runs appear on the Actions tab for each workflow.
+          - [ ] Check that \`rmpa.org/competitions\` has the ${YEAR} season events listed
+          - [ ] Confirm the next scheduled runs appear on the [Actions tab](../../actions)
 
           ---
           *Filed automatically by the season lifecycle workflow.*"
 
-      - name: File disable issue
+      # ---------------------------------------------------------------
+      # DISABLE — disable workflows
+      # ---------------------------------------------------------------
+
+      - name: Disable season workflows
+        if: steps.action.outputs.type == 'disable'
+        env:
+          GH_TOKEN: ${{ secrets.PIPELINE_PAT }}
+        run: |
+          WORKFLOWS="schedule-watcher.yml score-poller.yml sunday-reconciliation.yml score-fallback.yml"
+          for wf in $WORKFLOWS; do
+            gh workflow disable "$wf"
+            echo "Disabled $wf"
+          done
+
+      - name: File disable summary issue
         if: steps.action.outputs.type == 'disable'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -92,38 +151,22 @@ jobs:
           YEAR=$(date +%Y)
           gh issue create \
             --repo "$GITHUB_REPOSITORY" \
-            --title "[Score Pipeline] Disable season workflows — $YEAR season complete" \
+            --title "[Score Pipeline] ${YEAR} season disabled" \
             --label "score-pipeline" \
-            --body "## Action needed
+            --body "## Season ${YEAR} pipeline disabled
 
-          The RMPA season has ended (finals typically mid-April). Disable the score ingestion workflows to avoid unnecessary cron invocations during the off-season.
+          The following actions were taken automatically:
 
-          ### Steps
+          - [x] Disabled \`schedule-watcher.yml\`
+          - [x] Disabled \`score-poller.yml\`
+          - [x] Disabled \`sunday-reconciliation.yml\`
+          - [x] Disabled \`score-fallback.yml\`
 
-          1. Go to **Actions** → each workflow listed below → **Disable workflow**
-          2. Confirm no pending \`score-pipeline\` issues remain open
+          The \`season-lifecycle.yml\` workflow remains enabled and will re-enable the pipeline next January.
 
-          ### Workflows to disable
+          ### Review
 
-          | Workflow | File |
-          |----------|------|
-          | Schedule Watcher | \`schedule-watcher.yml\` |
-          | Score Poller | \`score-poller.yml\` |
-          | Sunday Reconciliation | \`sunday-reconciliation.yml\` |
-          | Score Fallback | \`score-fallback.yml\` |
-
-          ### CLI commands
-
-          \`\`\`bash
-          gh workflow disable schedule-watcher.yml
-          gh workflow disable score-poller.yml
-          gh workflow disable sunday-reconciliation.yml
-          gh workflow disable score-fallback.yml
-          \`\`\`
-
-          ### What stays enabled
-
-          The **Season Lifecycle** workflow (\`season-lifecycle.yml\`) stays enabled year-round. It will file another enable issue next January.
+          - [ ] Close any remaining open \`score-pipeline\` issues
 
           ---
           *Filed automatically by the season lifecycle workflow.*"

--- a/docs/designs/AUTO_SCORE_PIPELINE.md
+++ b/docs/designs/AUTO_SCORE_PIPELINE.md
@@ -688,7 +688,7 @@ type PollState = {
 
 ### Purpose
 
-Stages 1–4 should be **disabled during the off-season** (May–January) to avoid unnecessary cron invocations and billable minutes. Two year-round cron jobs file GitHub issues with instructions to enable or disable the season workflows.
+Stages 1–4 should be **disabled during the off-season** (May–January) to avoid unnecessary cron invocations and billable minutes. A year-round lifecycle workflow automatically enables and disables the season workflows using a PAT with `actions: write` scope (stored as the `PIPELINE_PAT` repository secret).
 
 ### Historical Season Dates
 
@@ -834,21 +834,26 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
 
-### Why Issues Instead of Auto-Enable/Disable?
+### Required Secret: `PIPELINE_PAT`
 
-GitHub Actions does not support enabling/disabling workflows programmatically via the standard `GITHUB_TOKEN`. The [workflow enable/disable API](https://docs.github.com/en/rest/actions/workflows#enable-a-workflow) requires a PAT or GitHub App token with `actions: write` scope. Filing an issue with clear instructions is simpler, avoids storing additional secrets, and gives the maintainer a checkpoint to verify the season setup (e.g., confirming `season.json` exists for the new year).
+The lifecycle workflow uses a fine-grained Personal Access Token (stored as the `PIPELINE_PAT` repository secret) to call the GitHub workflow enable/disable API. The default `GITHUB_TOKEN` does not have `actions: write` scope.
 
-If a PAT or GitHub App is later configured for the pipeline's auto-commit functionality (see [Auto-Commit to `main`](#auto-commit-to-main)), the lifecycle workflow could be upgraded to enable/disable workflows directly.
+**Setup:** Create a fine-grained PAT at [github.com/settings/tokens](https://github.com/settings/tokens) with `actions: write` permission scoped to this repository. Add it as a repository secret named `PIPELINE_PAT`.
 
 ---
 
 ## Season Lifecycle
 
-### Season Start (late January)
+### Season Start (late January) — Automatic
 
-1. **Season lifecycle workflow** files a GitHub issue with enable instructions
-2. Maintainer enables Stages 1–4 workflows and creates `public/data/<year>/season.json`
-3. Pipeline begins watching automatically when the first competition weekend arrives
+The lifecycle workflow automatically:
+
+1. Creates `public/data/<year>/season.json` if it doesn't exist
+2. Resets `public/data/poll-state.json` for the new season
+3. Commits the changes to `main`
+4. Enables Stages 1–4 workflows via the `PIPELINE_PAT`
+5. Files a summary issue with a verification checklist
+6. Pipeline begins watching automatically when the first competition weekend arrives
 
 ### During Season (February–April)
 
@@ -859,10 +864,9 @@ If a PAT or GitHub App is later configured for the pipeline's auto-commit functi
 - Daily fallback catches anything else
 - GitHub issues surface any problems requiring manual attention
 
-### Off-Season (May–January)
+### Off-Season (May–January) — Automatic
 
-- **Season lifecycle workflow** files a GitHub issue with disable instructions (April 30)
-- Maintainer disables Stages 1–4 workflows
+- **Season lifecycle workflow** disables Stages 1–4 workflows and files a summary issue (April 30)
 - Only the season lifecycle workflow remains enabled (2 cron entries, fires once each in January and April)
 - **Zero billable minutes** from Stages 1–4 during the off-season
 

--- a/src/pipeline/README.md
+++ b/src/pipeline/README.md
@@ -9,65 +9,40 @@ For the implementation plan, see [`docs/plans/pipeline-implementation-plan.md`](
 
 ## Season Checklist
 
-### Pre-Season Setup (late January)
+### Pre-Season Setup (late January) — Automatic
 
-The `season-lifecycle.yml` workflow automatically files a GitHub issue on **January 25** with these instructions. You can also run it manually via `workflow_dispatch` with the `enable` action.
+On **January 25**, the `season-lifecycle.yml` workflow automatically:
 
-1. **Create the season data directory** (if it doesn't exist):
+1. Creates `public/data/<YEAR>/season.json` (if it doesn't exist)
+2. Resets `public/data/poll-state.json` for the new season
+3. Commits the changes to `main`
+4. Enables all 4 season workflows (`schedule-watcher`, `score-poller`, `sunday-reconciliation`, `score-fallback`)
+5. Files a summary issue with a verification checklist
 
-   ```bash
-   mkdir -p public/data/<YEAR>
-   ```
+**Your only task:** check the summary issue and verify `rmpa.org/competitions` has the new season's events listed.
 
-2. **Create `season.json`** for the new year:
+You can also trigger this manually: Actions → Season Lifecycle → Run workflow → select `enable`.
 
-   ```json
-   {
-     "year": <YEAR>,
-     "shows": [],
-     "classes": []
-   }
-   ```
+### Post-Season Teardown (late April) — Automatic
 
-3. **Reset `poll-state.json`** for the new season:
+On **April 30**, the `season-lifecycle.yml` workflow automatically:
 
-   ```json
-   {
-     "season": <YEAR>,
-     "retreats": [],
-     "coolDownUntilUtc": null
-   }
-   ```
+1. Disables all 4 season workflows
+2. Files a summary issue
 
-4. **Verify `rmpa.org/competitions`** has the new season's events and schedule links published.
+**Your only task:** review and close any remaining open `score-pipeline` issues.
 
-5. **Enable the season workflows:**
+`season-lifecycle.yml` stays enabled year-round and will re-enable the pipeline next January.
 
-   ```bash
-   gh workflow enable schedule-watcher.yml
-   gh workflow enable score-poller.yml
-   gh workflow enable sunday-reconciliation.yml
-   gh workflow enable score-fallback.yml
-   ```
+You can also trigger this manually: Actions → Season Lifecycle → Run workflow → select `disable`.
 
-6. **Verify** the workflows appear as enabled on the Actions tab with their next scheduled run times.
+### Required Secret: `PIPELINE_PAT`
 
-### Post-Season Teardown (late April)
+The lifecycle workflow uses a Personal Access Token to enable/disable other workflows (the default `GITHUB_TOKEN` can't do this). The PAT needs the **`actions: write`** scope.
 
-The `season-lifecycle.yml` workflow automatically files a GitHub issue on **April 30** with these instructions. You can also run it manually via `workflow_dispatch` with the `disable` action.
-
-1. **Disable the season workflows:**
-
-   ```bash
-   gh workflow disable schedule-watcher.yml
-   gh workflow disable score-poller.yml
-   gh workflow disable sunday-reconciliation.yml
-   gh workflow disable score-fallback.yml
-   ```
-
-2. **Review open `score-pipeline` issues** — close any that are no longer relevant.
-
-3. **`season-lifecycle.yml` stays enabled year-round.** It will file the next enable issue on January 25.
+To set it up:
+1. Create a fine-grained PAT at [github.com/settings/tokens](https://github.com/settings/tokens) with `actions: write` permission scoped to this repository
+2. Add it as a repository secret named `PIPELINE_PAT` at Settings → Secrets and variables → Actions
 
 ---
 


### PR DESCRIPTION
## Summary
Replace the manual enable/disable instructions with full automation. The lifecycle workflow now directly manages the other workflows using a PAT.

### What changed
- **`season-lifecycle.yml`** — now creates season data, resets poll-state, enables/disables workflows directly, and commits changes to main. Still files summary issues, but as confirmations rather than action items.
- **Pipeline README** — updated to reflect zero-manual-step lifecycle. Added `PIPELINE_PAT` setup instructions.
- **Design doc** — updated Stage 5, Season Lifecycle, and removed the "Why Issues Instead" section.

### Required setup
Add a **`PIPELINE_PAT`** repository secret:
1. Create a fine-grained PAT at github.com/settings/tokens with `actions: write` permission scoped to this repo
2. Add it as a repository secret named `PIPELINE_PAT` at Settings → Secrets → Actions

### What's now automatic

| Action | When | Manual step remaining |
|--------|------|----------------------|
| Create season.json | Jan 25 | None |
| Reset poll-state.json | Jan 25 | None |
| Enable season workflows | Jan 25 | None |
| Disable season workflows | Apr 30 | None |
| Verify rmpa.org/competitions | Jan 25 | Check the summary issue |
| Review open pipeline issues | Apr 30 | Check the summary issue |

## Test plan
- [x] All 211 tests pass
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)