### PR TITLE
fix: use PIPELINE_PAT for git push in all pipeline workflows

### DIFF
--- a/.github/workflows/schedule-watcher.yml
+++ b/.github/workflows/schedule-watcher.yml
@@ -11,10 +11,10 @@ on:
 jobs:
   watch:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.PIPELINE_PAT }}
 
       - uses: actions/setup-node@v5
         with:

--- a/.github/workflows/score-fallback.yml
+++ b/.github/workflows/score-fallback.yml
@@ -12,10 +12,11 @@ jobs:
   fallback:
     runs-on: ubuntu-latest
     permissions:
-      contents: write
       issues: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.PIPELINE_PAT }}
 
       - uses: actions/setup-node@v5
         with:

--- a/.github/workflows/score-poller.yml
+++ b/.github/workflows/score-poller.yml
@@ -12,10 +12,11 @@ jobs:
   poll:
     runs-on: ubuntu-latest
     permissions:
-      contents: write
       issues: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.PIPELINE_PAT }}
 
       - uses: actions/setup-node@v5
         with:

--- a/.github/workflows/season-lifecycle.yml
+++ b/.github/workflows/season-lifecycle.yml
@@ -20,10 +20,11 @@ jobs:
   lifecycle:
     runs-on: ubuntu-latest
     permissions:
-      contents: write
       issues: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.PIPELINE_PAT }}
 
       - name: Determine action
         id: action
@@ -75,7 +76,7 @@ jobs:
           }" > "$POLL_STATE"
           echo "Reset ${POLL_STATE} for ${YEAR}"
 
-      - name: Commit season data
+      - name: Commit and push season data
         if: steps.action.outputs.type == 'enable'
         run: |
           git config user.name "score-pipeline[bot]"

--- a/.github/workflows/sunday-reconciliation.yml
+++ b/.github/workflows/sunday-reconciliation.yml
@@ -12,10 +12,11 @@ jobs:
   reconcile:
     runs-on: ubuntu-latest
     permissions:
-      contents: write
       issues: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.PIPELINE_PAT }}
 
       - uses: actions/setup-node@v5
         with:


### PR DESCRIPTION
## Summary
Fix the branch protection push rejection by using `PIPELINE_PAT` in `actions/checkout` for all 5 pipeline workflows. The PAT authenticates as the repo owner, which has push access to `main` without needing a branch protection bypass rule.

### What changed
- All 5 pipeline workflows now pass `token: ${{ secrets.PIPELINE_PAT }}` to `actions/checkout`
- Removed `contents: write` permission where it was the only permission (PAT handles auth)
- Removed the `RepositoryRole` bypass actor from the ruleset (no longer needed)

### Why
The default `GITHUB_TOKEN` from `actions/checkout` can't push to protected branches. Passing the PAT to checkout configures the git remote URL with the token, so `git push` authenticates as the repo owner.

## Test plan
- [x] Build succeeds
- [ ] Test with `gh workflow run season-lifecycle.yml -f action=enable` after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)