### PR TITLE
fix: mark actionable retreats as imported when scores exist but are unchanged

### DIFF
--- a/src/pipeline/cli/pollScores.ts
+++ b/src/pipeline/cli/pollScores.ts
@@ -103,6 +103,14 @@ async function main(): Promise<void> {
     const comparison = compareHash(currentHash, previousHash)
 
     if (comparison.status === 'unchanged') {
+      // Scores exist but haven't changed — mark any actionable retreats as
+      // imported so they don't time out (covers the case where an earlier
+      // retreat already imported these scores on a previous poller run)
+      for (const retreat of actionable) {
+        if (retreat.status === 'pending') {
+          state = markRetreatImported(state, retreat.retreatUtc, currentHash, now)
+        }
+      }
       continue
     }
 
@@ -165,9 +173,11 @@ async function main(): Promise<void> {
 
     imported = true
 
-    // Mark matching retreat as imported
+    // Mark actionable retreats as imported
     for (const retreat of actionable) {
-      state = markRetreatImported(state, retreat.retreatUtc, currentHash, now)
+      if (retreat.status === 'pending') {
+        state = markRetreatImported(state, retreat.retreatUtc, currentHash, now)
+      }
     }
   }
 

--- a/src/pipeline/integration.test.ts
+++ b/src/pipeline/integration.test.ts
@@ -209,6 +209,55 @@ describe('Season Simulation — 2025 model', () => {
       expect(isCoolDownActive(state, new Date('2025-02-09T01:05:00Z'))).toBe(false)
     })
 
+    it('should mark later retreat as imported via unchanged hash when earlier retreat already imported', () => {
+      // Simulate "Full Retreat" at 8:07 PM and "Retreat Concludes" at 8:37 PM
+      const retreat1Utc = '2025-02-09T02:07:00.000Z'
+      const retreat2Utc = '2025-02-09T02:37:00.000Z'
+      let state = emptyPollState(2025)
+      state = addOrUpdateRetreat(state, makeRetreatEntry('2025-02-08', 'Show — Full Retreat', retreat1Utc))
+      state = addOrUpdateRetreat(state, makeRetreatEntry('2025-02-08', 'Show — Retreat Concludes', retreat2Utc))
+
+      const hash = hashContent(loadRecap(RECAP_FILES[0]))
+
+      // Step 1: At 8:10 PM, "Full Retreat" is actionable → import succeeds
+      const time1 = new Date('2025-02-09T02:10:00Z')
+      const actionable1 = findActionableRetreats(state, time1)
+      expect(actionable1).toHaveLength(1)
+      expect(actionable1[0].eventName).toBe('Show — Full Retreat')
+
+      // Mark only the actionable retreat
+      for (const retreat of actionable1) {
+        if (retreat.status === 'pending') {
+          state = markRetreatImported(state, retreat.retreatUtc, hash, time1)
+        }
+      }
+      expect(state.retreats[0].status).toBe('imported')
+      expect(state.retreats[1].status).toBe('pending')
+
+      // Step 2: At 8:40 PM, "Retreat Concludes" is actionable → scores exist
+      // but hash is unchanged. The poller should still mark it imported.
+      const time2 = new Date('2025-02-09T02:40:00Z')
+      const actionable2 = findActionableRetreats(state, time2)
+      expect(actionable2).toHaveLength(1)
+      expect(actionable2[0].eventName).toBe('Show — Retreat Concludes')
+
+      // Simulate the "unchanged" branch: scores exist, hash matches
+      const comparison = compareHash(hash, hash)
+      expect(comparison.status).toBe('unchanged')
+
+      // Mark actionable retreats as imported on unchanged (scores are there)
+      for (const retreat of actionable2) {
+        if (retreat.status === 'pending') {
+          state = markRetreatImported(state, retreat.retreatUtc, hash, time2)
+        }
+      }
+
+      // Both should now be imported — no spurious timeout
+      expect(state.retreats[0].status).toBe('imported')
+      expect(state.retreats[1].status).toBe('imported')
+      expect(hasWork(state, new Date('2025-02-09T05:00:00Z'))).toBe(false)
+    })
+
     it('should not find actionable retreats after import (no more work)', () => {
       const retreatUtc = '2025-02-09T00:28:00.000Z'
       let state = emptyPollState(2025)


### PR DESCRIPTION
## Summary
Fix a bug where multiple retreat entries on the same date (e.g. "Full Retreat" at 8:07 PM and "Retreat Concludes" at 8:37 PM) would cause the later retreat to time out and file a spurious "scores not posted" issue.

### The bug
1. "Full Retreat" becomes actionable at 8:07 PM → poller imports scores → marked `imported`
2. "Retreat Concludes" becomes actionable at 8:37 PM → poller fetches scores → hash matches (unchanged) → skipped entirely
3. "Retreat Concludes" stays `pending` → hits 2-hour window close → marked `failed` → spurious issue filed

### The fix
When the poller finds scores on the page but the hash is unchanged (already imported), mark any currently actionable retreats as `imported`. The scores are there — they just didn't change since the last run.

This correctly handles both cases:
- **Same-event retreats** (Full Retreat + Retreat Concludes): the later one sees unchanged scores and is marked imported
- **Distinct shows on the same date** (midday + evening): different recap URLs with different hashes, handled independently

### Test added
"should mark later retreat as imported via unchanged hash when earlier retreat already imported" — walks through the exact Full Retreat → Retreat Concludes sequence step by step.

## Test plan
- [x] 212 tests pass
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)