### PR TITLE
docs: add workflows scope to PIPELINE_PAT requirements

### DIFF
--- a/docs/designs/AUTO_SCORE_PIPELINE.md
+++ b/docs/designs/AUTO_SCORE_PIPELINE.md
@@ -846,9 +846,9 @@ jobs:
 
 ### Required Secret: `PIPELINE_PAT`
 
-The lifecycle workflow uses a fine-grained Personal Access Token (stored as the `PIPELINE_PAT` repository secret) to call the GitHub workflow enable/disable API. The default `GITHUB_TOKEN` does not have `actions: write` scope.
+The pipeline uses a fine-grained Personal Access Token (stored as the `PIPELINE_PAT` repository secret) to enable/disable workflows and push changes to workflow files (`.github/workflows/`). The default `GITHUB_TOKEN` cannot do either.
 
-**Setup:** Create a fine-grained PAT at [github.com/settings/tokens](https://github.com/settings/tokens) with `actions: write` permission scoped to this repository. Add it as a repository secret named `PIPELINE_PAT`.
+**Setup:** Create a fine-grained PAT at [github.com/settings/tokens](https://github.com/settings/tokens) with `actions: write`, `contents: write`, and `workflows: write` permissions scoped to this repository. Add it as a repository secret named `PIPELINE_PAT`.
 
 ---
 

--- a/src/pipeline/README.md
+++ b/src/pipeline/README.md
@@ -38,10 +38,10 @@ You can also trigger this manually: Actions → Season Lifecycle → Run workflo
 
 ### Required Secret: `PIPELINE_PAT`
 
-The lifecycle workflow uses a Personal Access Token to enable/disable other workflows (the default `GITHUB_TOKEN` can't do this). The PAT needs the **`actions: write`** and **`contents: write`** scopes.
+The lifecycle workflow uses a Personal Access Token to enable/disable other workflows and push workflow file changes (the default `GITHUB_TOKEN` can't do this). The PAT needs the **`actions: write`**, **`contents: write`**, and **`workflows: write`** scopes.
 
 To set it up:
-1. Create a fine-grained PAT at [github.com/settings/tokens](https://github.com/settings/tokens) with `actions: write` and `contents: write` permissions scoped to this repository
+1. Create a fine-grained PAT at [github.com/settings/tokens](https://github.com/settings/tokens) with `actions: write`, `contents: write`, and `workflows: write` permissions scoped to this repository
 2. Add it as a repository secret named `PIPELINE_PAT` at Settings → Secrets and variables → Actions
 
 ---


### PR DESCRIPTION
## Summary
- The `PIPELINE_PAT` needs `workflows: write` scope to push changes to `.github/workflows/score-poller.yml`
- Updated README and design doc to list all three required scopes: `actions: write`, `contents: write`, `workflows: write`

## Test plan
- [x] Docs-only change, tests pass, build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)