### PR TITLE
fix(data): remove stale Retreat Concludes entry

### DIFF
--- a/.github/workflows/score-poller.yml
+++ b/.github/workflows/score-poller.yml
@@ -5,8 +5,6 @@ on:
     # --- DYNAMIC CRON START ---
     # retreat:2026-04-05T02:07:00.000Z final:true
     - cron: '*/3 2-4 * * 0'
-    # retreat:2026-04-05T02:37:00.000Z final:true
-    - cron: '*/3 2-4 * * 0'
     # --- DYNAMIC CRON END ---
   workflow_dispatch: {}
 

--- a/data/poll-state.json
+++ b/data/poll-state.json
@@ -10,15 +10,6 @@
       "sourceHash": null,
       "lastImportedUtc": null,
       "isFinal": true
-    },
-    {
-      "date": "2026-04-04",
-      "eventName": "Championships Finals @ Denver Coliseum — Retreat Concludes",
-      "retreatUtc": "2026-04-05T02:37:00.000Z",
-      "windowCloseUtc": "2026-04-05T04:37:00.000Z",
-      "status": "pending",
-      "sourceHash": null,
-      "lastImportedUtc": null
     }
   ],
   "coolDownUntilUtc": null


### PR DESCRIPTION
## Summary
- Removes stale "Retreat Concludes" entry from `poll-state.json` that predated the `/concludes/i` filter in `parseScheduleRetreats`
- Removes the duplicate cron line it generated in `score-poller.yml`

## Test plan
- [x] Verified `poll-state.json` is valid JSON with single retreat entry
- [x] Verified `score-poller.yml` has one cron entry for the Championships Finals retreat

🤖 Generated with [Claude Code](https://claude.com/claude-code)