### PR TITLE
fix: make poller cron date-specific with MT comments

### DIFF
--- a/src/pipeline/pollerCron.test.ts
+++ b/src/pipeline/pollerCron.test.ts
@@ -28,7 +28,7 @@ describe('computeCronWindows', () => {
 
   describe('Scenario 1: single show, single retreat', () => {
     it('should return one window for a Saturday evening retreat', () => {
-      // 8:07 PM MDT Saturday = 02:07 UTC Sunday, window close 04:07 UTC
+      // 8:07 PM MDT Saturday = 02:07 UTC Sunday Apr 5, window close 04:07 UTC
       const r = makeRetreatEntry('2026-04-04', 'Show — Retreat', '2026-04-05T02:07:00.000Z')
       const windows = computeCronWindows([r])
 
@@ -36,14 +36,16 @@ describe('computeCronWindows', () => {
       expect(windows[0]).toMatchObject({
         startHourUtc: 2,
         endHourUtc: 4,
-        dayOfWeekUtc: 0, // Sunday UTC
+        dayOfMonthUtc: 5,
+        monthUtc: 4,
         retreatUtc: '2026-04-05T02:07:00.000Z',
         isFinal: true,
       })
+      expect(windows[0].retreatMt).toMatch(/Sat.*8:07.*PM.*MDT/)
     })
 
     it('should return one window for an early evening MST retreat', () => {
-      // 5:28 PM MST Saturday = 00:28 UTC Sunday, window close 02:28 UTC
+      // 5:28 PM MST Saturday = 00:28 UTC Sunday Feb 15, window close 02:28 UTC
       const r = makeRetreatEntry('2026-02-14', 'Show — Retreat', '2026-02-15T00:28:00.000Z')
       const windows = computeCronWindows([r])
 
@@ -51,8 +53,10 @@ describe('computeCronWindows', () => {
       expect(windows[0]).toMatchObject({
         startHourUtc: 0,
         endHourUtc: 2,
-        dayOfWeekUtc: 0, // Sunday UTC
+        dayOfMonthUtc: 15,
+        monthUtc: 2,
       })
+      expect(windows[0].retreatMt).toMatch(/Sat.*5:28.*PM.*MST/)
     })
   })
 
@@ -71,18 +75,20 @@ describe('computeCronWindows', () => {
       const windows = computeCronWindows([midDay, evening])
 
       expect(windows).toHaveLength(2)
-      // Mid-day window: 19–21 UTC Saturday
+      // Mid-day window: 19–21 UTC Feb 28
       expect(windows[0]).toMatchObject({
         startHourUtc: 19,
         endHourUtc: 21,
-        dayOfWeekUtc: 6, // Saturday
+        dayOfMonthUtc: 28,
+        monthUtc: 2,
         isFinal: false,
       })
-      // Evening window: 1–3 UTC Sunday
+      // Evening window: 1–3 UTC Mar 1
       expect(windows[1]).toMatchObject({
         startHourUtc: 1,
         endHourUtc: 3,
-        dayOfWeekUtc: 0, // Sunday
+        dayOfMonthUtc: 1,
+        monthUtc: 3,
         isFinal: true,
       })
     })
@@ -132,11 +138,11 @@ describe('computeCronWindows', () => {
       expect(windows[1].retreatUtc).toBe('2026-03-28T01:55:00.000Z')
       expect(windows[2].retreatUtc).toBe('2026-03-28T19:45:00.000Z')
       expect(windows[3].retreatUtc).toBe('2026-03-29T01:55:00.000Z')
-      // Distinct UTC days (no union)
-      expect(windows[0].dayOfWeekUtc).toBe(5) // Friday
-      expect(windows[1].dayOfWeekUtc).toBe(6) // Saturday
-      expect(windows[2].dayOfWeekUtc).toBe(6) // Saturday
-      expect(windows[3].dayOfWeekUtc).toBe(0) // Sunday
+      // Distinct UTC dates
+      expect(windows[0]).toMatchObject({ dayOfMonthUtc: 27, monthUtc: 3 })
+      expect(windows[1]).toMatchObject({ dayOfMonthUtc: 28, monthUtc: 3 })
+      expect(windows[2]).toMatchObject({ dayOfMonthUtc: 28, monthUtc: 3 })
+      expect(windows[3]).toMatchObject({ dayOfMonthUtc: 29, monthUtc: 3 })
       // Final flags
       expect(windows[0].isFinal).toBe(false)
       expect(windows[1].isFinal).toBe(true)
@@ -173,13 +179,15 @@ describe('computeCronWindows', () => {
       expect(windows[0]).toMatchObject({
         startHourUtc: 2,
         endHourUtc: 4,
-        dayOfWeekUtc: 6, // Saturday UTC (Friday night MT)
+        dayOfMonthUtc: 28,
+        monthUtc: 3,
         isFinal: true,
       })
       expect(windows[1]).toMatchObject({
         startHourUtc: 2,
         endHourUtc: 4,
-        dayOfWeekUtc: 0, // Sunday UTC (Saturday night MT)
+        dayOfMonthUtc: 29,
+        monthUtc: 3,
         isFinal: true,
       })
     })
@@ -191,7 +199,7 @@ describe('computeCronWindows', () => {
 
       const windows = computeCronWindows([fri, sat])
       expect(windows).toHaveLength(1)
-      expect(windows[0].dayOfWeekUtc).toBe(0)
+      expect(windows[0].dayOfMonthUtc).toBe(29)
     })
   })
 
@@ -207,17 +215,19 @@ describe('computeCronWindows', () => {
       const windows = computeCronWindows([thisWeek, nextWeek])
 
       expect(windows).toHaveLength(2)
-      // Both are Sunday UTC but a week apart — each gets its own cron entry
+      // Both are in February but a week apart — each gets its own date-specific cron
       expect(windows[0]).toMatchObject({
         startHourUtc: 2,
         endHourUtc: 4,
-        dayOfWeekUtc: 0, // Sunday
+        dayOfMonthUtc: 15,
+        monthUtc: 2,
         retreatUtc: '2026-02-15T02:07:00.000Z',
       })
       expect(windows[1]).toMatchObject({
         startHourUtc: 2,
         endHourUtc: 4,
-        dayOfWeekUtc: 0, // Sunday
+        dayOfMonthUtc: 22,
+        monthUtc: 2,
         retreatUtc: '2026-02-22T02:07:00.000Z',
       })
     })
@@ -262,17 +272,19 @@ describe('formatCronEntries', () => {
     expect(formatCronEntries([])).toEqual(["- cron: '0 0 31 2 *'"])
   })
 
-  it('should format a single window with metadata comment', () => {
+  it('should format a single window with metadata comment including MT', () => {
     const windows: Array<CronWindow> = [{
       startHourUtc: 2,
       endHourUtc: 4,
-      dayOfWeekUtc: 0,
+      dayOfMonthUtc: 5,
+      monthUtc: 4,
       retreatUtc: '2026-04-05T02:07:00.000Z',
+      retreatMt: 'Sat 8:07 PM MDT',
       isFinal: true,
     }]
     expect(formatCronEntries(windows)).toEqual([
-      '# retreat:2026-04-05T02:07:00.000Z final:true',
-      "- cron: '*/3 2-4 * * 0'",
+      '# retreat:2026-04-05T02:07:00.000Z mt:Sat 8:07 PM MDT final:true',
+      "- cron: '*/3 2-4 5 4 *'",
     ])
   })
 
@@ -281,62 +293,68 @@ describe('formatCronEntries', () => {
       {
         startHourUtc: 19,
         endHourUtc: 21,
-        dayOfWeekUtc: 6,
+        dayOfMonthUtc: 28,
+        monthUtc: 2,
         retreatUtc: '2026-02-28T19:45:00.000Z',
+        retreatMt: 'Sat 12:45 PM MST',
         isFinal: false,
       },
       {
         startHourUtc: 1,
         endHourUtc: 3,
-        dayOfWeekUtc: 0,
+        dayOfMonthUtc: 1,
+        monthUtc: 3,
         retreatUtc: '2026-03-01T01:55:00.000Z',
+        retreatMt: 'Sat 6:55 PM MST',
         isFinal: true,
       },
     ]
     expect(formatCronEntries(windows)).toEqual([
-      '# retreat:2026-02-28T19:45:00.000Z final:false',
-      "- cron: '*/3 19-21 * * 6'",
-      '# retreat:2026-03-01T01:55:00.000Z final:true',
-      "- cron: '*/3 1-3 * * 0'",
+      '# retreat:2026-02-28T19:45:00.000Z mt:Sat 12:45 PM MST final:false',
+      "- cron: '*/3 19-21 28 2 *'",
+      '# retreat:2026-03-01T01:55:00.000Z mt:Sat 6:55 PM MST final:true',
+      "- cron: '*/3 1-3 1 3 *'",
     ])
   })
 
   it('should format four windows for back-to-back double-retreat days', () => {
     const windows: Array<CronWindow> = [
-      { startHourUtc: 19, endHourUtc: 21, dayOfWeekUtc: 5, retreatUtc: '2026-03-27T19:45:00.000Z', isFinal: false },
-      { startHourUtc: 1, endHourUtc: 3, dayOfWeekUtc: 6, retreatUtc: '2026-03-28T01:55:00.000Z', isFinal: true },
-      { startHourUtc: 19, endHourUtc: 21, dayOfWeekUtc: 6, retreatUtc: '2026-03-28T19:45:00.000Z', isFinal: false },
-      { startHourUtc: 1, endHourUtc: 3, dayOfWeekUtc: 0, retreatUtc: '2026-03-29T01:55:00.000Z', isFinal: true },
+      { startHourUtc: 19, endHourUtc: 21, dayOfMonthUtc: 27, monthUtc: 3, retreatUtc: '2026-03-27T19:45:00.000Z', retreatMt: 'Fri 12:45 PM MDT', isFinal: false },
+      { startHourUtc: 1, endHourUtc: 3, dayOfMonthUtc: 28, monthUtc: 3, retreatUtc: '2026-03-28T01:55:00.000Z', retreatMt: 'Fri 7:55 PM MDT', isFinal: true },
+      { startHourUtc: 19, endHourUtc: 21, dayOfMonthUtc: 28, monthUtc: 3, retreatUtc: '2026-03-28T19:45:00.000Z', retreatMt: 'Sat 12:45 PM MDT', isFinal: false },
+      { startHourUtc: 1, endHourUtc: 3, dayOfMonthUtc: 29, monthUtc: 3, retreatUtc: '2026-03-29T01:55:00.000Z', retreatMt: 'Sat 7:55 PM MDT', isFinal: true },
     ]
     const lines = formatCronEntries(windows)
     expect(lines).toHaveLength(8) // 4 metadata + 4 cron
-    expect(lines[0]).toBe('# retreat:2026-03-27T19:45:00.000Z final:false')
-    expect(lines[1]).toBe("- cron: '*/3 19-21 * * 5'")
-    expect(lines[6]).toBe('# retreat:2026-03-29T01:55:00.000Z final:true')
-    expect(lines[7]).toBe("- cron: '*/3 1-3 * * 0'")
+    expect(lines[0]).toBe('# retreat:2026-03-27T19:45:00.000Z mt:Fri 12:45 PM MDT final:false')
+    expect(lines[1]).toBe("- cron: '*/3 19-21 27 3 *'")
+    expect(lines[6]).toBe('# retreat:2026-03-29T01:55:00.000Z mt:Sat 7:55 PM MDT final:true')
+    expect(lines[7]).toBe("- cron: '*/3 1-3 29 3 *'")
   })
 
   it('should format single-hour window without dash range', () => {
     const windows: Array<CronWindow> = [{
       startHourUtc: 3,
       endHourUtc: 3,
-      dayOfWeekUtc: 0,
+      dayOfMonthUtc: 15,
+      monthUtc: 2,
       retreatUtc: '2026-02-15T03:00:00.000Z',
+      retreatMt: 'Sat 8:00 PM MST',
       isFinal: true,
     }]
     const lines = formatCronEntries(windows)
-    expect(lines).toContain("- cron: '*/3 3 * * 0'")
+    expect(lines).toContain("- cron: '*/3 3 15 2 *'")
   })
 
   it('should format two distinct windows for back-to-back single retreats', () => {
     const windows: Array<CronWindow> = [
-      { startHourUtc: 2, endHourUtc: 4, dayOfWeekUtc: 6, retreatUtc: '2026-03-28T02:07:00.000Z', isFinal: true },
-      { startHourUtc: 2, endHourUtc: 4, dayOfWeekUtc: 0, retreatUtc: '2026-03-29T02:07:00.000Z', isFinal: true },
+      { startHourUtc: 2, endHourUtc: 4, dayOfMonthUtc: 28, monthUtc: 3, retreatUtc: '2026-03-28T02:07:00.000Z', retreatMt: 'Fri 8:07 PM MDT', isFinal: true },
+      { startHourUtc: 2, endHourUtc: 4, dayOfMonthUtc: 29, monthUtc: 3, retreatUtc: '2026-03-29T02:07:00.000Z', retreatMt: 'Sat 8:07 PM MDT', isFinal: true },
     ]
     const lines = formatCronEntries(windows)
     expect(lines).toHaveLength(4)
-    // Each window gets its own cron entry with its own day
-    expect(lines[1]).toBe("- cron: '*/3 2-4 * * 6'")
-    expect(lines[3]).toBe("- cron: '*/3 2-4 * * 0'")
+    // Each window gets its own date-specific cron entry
+    expect(lines[1]).toBe("- cron: '*/3 2-4 28 3 *'")
+    expect(lines[3]).toBe("- cron: '*/3 2-4 29 3 *'")
   })
 })

--- a/src/pipeline/pollerCron.ts
+++ b/src/pipeline/pollerCron.ts
@@ -21,8 +21,10 @@ const CRON_END_MARKER = '# --- DYNAMIC CRON END ---'
 type CronWindow = {
   startHourUtc: number
   endHourUtc: number
-  dayOfWeekUtc: number
+  dayOfMonthUtc: number
+  monthUtc: number
   retreatUtc: string
+  retreatMt: string
   isFinal: boolean
 }
 
@@ -41,8 +43,10 @@ function computeCronWindows(retreats: Array<RetreatEntry>): Array<CronWindow> {
       return {
         startHourUtc: retreatDate.getUTCHours(),
         endHourUtc: closeDate.getUTCHours(),
-        dayOfWeekUtc: retreatDate.getUTCDay(),
+        dayOfMonthUtc: retreatDate.getUTCDate(),
+        monthUtc: retreatDate.getUTCMonth() + 1,
         retreatUtc: r.retreatUtc,
+        retreatMt: formatMountainTime(retreatDate),
         isFinal: r.isFinal ?? true,
       }
     })
@@ -50,9 +54,33 @@ function computeCronWindows(retreats: Array<RetreatEntry>): Array<CronWindow> {
 }
 
 /**
+ * Format a UTC Date as a short Mountain Time string for cron comments.
+ * e.g. "Sat 8:07 PM MDT" or "Sat 5:28 PM MST"
+ */
+function formatMountainTime(date: Date): string {
+  const parts = new Intl.DateTimeFormat('en-US', {
+    timeZone: 'America/Denver',
+    weekday: 'short',
+    hour: 'numeric',
+    minute: '2-digit',
+    hour12: true,
+    timeZoneName: 'short',
+  }).formatToParts(date)
+
+  const weekday = parts.find((p) => p.type === 'weekday')?.value ?? ''
+  const hour = parts.find((p) => p.type === 'hour')?.value ?? ''
+  const minute = parts.find((p) => p.type === 'minute')?.value ?? ''
+  const dayPeriod = parts.find((p) => p.type === 'dayPeriod')?.value ?? ''
+  const tz = parts.find((p) => p.type === 'timeZoneName')?.value ?? ''
+
+  return `${weekday} ${hour}:${minute} ${dayPeriod} ${tz}`
+}
+
+/**
  * Format CronWindows as YAML lines with metadata comments.
  *
  * Each window produces two lines: a metadata comment and a cron entry.
+ * Cron uses day-of-month + month (not day-of-week) for date specificity.
  * Returns a never-fire cron if windows is empty.
  */
 function formatCronEntries(windows: Array<CronWindow>): Array<string> {
@@ -63,8 +91,8 @@ function formatCronEntries(windows: Array<CronWindow>): Array<string> {
     const hourRange = w.startHourUtc === w.endHourUtc
       ? `${w.startHourUtc}`
       : `${w.startHourUtc}-${w.endHourUtc}`
-    lines.push(`# retreat:${w.retreatUtc} final:${w.isFinal}`)
-    lines.push(`- cron: '*/3 ${hourRange} * * ${w.dayOfWeekUtc}'`)
+    lines.push(`# retreat:${w.retreatUtc} mt:${w.retreatMt} final:${w.isFinal}`)
+    lines.push(`- cron: '*/3 ${hourRange} ${w.dayOfMonthUtc} ${w.monthUtc} *'`)
   }
   return lines
 }
@@ -100,5 +128,5 @@ function writePollerCron(retreats: Array<RetreatEntry>): boolean {
 // Exports
 // ---------------------------------------------------------------------------
 
-export { computeCronWindows, formatCronEntries, writePollerCron, POLLER_WORKFLOW_PATH }
+export { computeCronWindows, formatCronEntries, formatMountainTime, writePollerCron, POLLER_WORKFLOW_PATH }
 export type { CronWindow }


### PR DESCRIPTION
## Summary
- Poller cron now uses day-of-month + month (`*/3 2-4 5 4 *`) instead of day-of-week (`*/3 2-4 * * 0`), so it only fires on the exact retreat date
- Metadata comments now include both UTC and Mountain Time: `# retreat:2026-04-05T02:07:00.000Z mt:Sat 8:07 PM MDT final:true`
- Replaced `dayOfWeekUtc` with `dayOfMonthUtc` + `monthUtc` in CronWindow type

## Test plan
- [x] All 233 tests pass with coverage thresholds met
- [x] Build compiles
- [ ] Re-run schedule watcher to verify generated cron is date-specific

🤖 Generated with [Claude Code](https://claude.com/claude-code)