### PR TITLE
chore: prefix pipeline workflow names for Actions UI grouping

### DIFF
--- a/.github/workflows/schedule-watcher.yml
+++ b/.github/workflows/schedule-watcher.yml
@@ -1,4 +1,4 @@
-name: Schedule Watcher
+name: "Pipeline: Schedule Watcher"
 
 on:
   schedule:

--- a/.github/workflows/score-fallback.yml
+++ b/.github/workflows/score-fallback.yml
@@ -1,4 +1,4 @@
-name: Score Fallback
+name: "Pipeline: Score Fallback"
 
 on:
   schedule:

--- a/.github/workflows/score-poller.yml
+++ b/.github/workflows/score-poller.yml
@@ -1,4 +1,4 @@
-name: Score Poller
+name: "Pipeline: Score Poller"
 
 on:
   schedule:

--- a/.github/workflows/season-lifecycle.yml
+++ b/.github/workflows/season-lifecycle.yml
@@ -1,4 +1,4 @@
-name: Season Lifecycle
+name: "Pipeline: Season Lifecycle"
 
 on:
   schedule:

--- a/.github/workflows/sunday-reconciliation.yml
+++ b/.github/workflows/sunday-reconciliation.yml
@@ -1,4 +1,4 @@
-name: Sunday Reconciliation
+name: "Pipeline: Sunday Reconciliation"
 
 on:
   schedule:


### PR DESCRIPTION
## Summary
- Add `Pipeline:` prefix to all 5 pipeline workflow display names
- Groups them together in the GitHub Actions tab for easier navigation
- No functional changes — `gh workflow enable/disable` uses filenames, not display names

## Test plan
- [x] Verified all `gh workflow` commands reference filenames (unaffected)
- [ ] Check Actions tab shows grouped names after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)