### PR TITLE
fix: allow tied ranks in score validation

### DIFF
--- a/src/pipeline/validate.test.ts
+++ b/src/pipeline/validate.test.ts
@@ -95,16 +95,44 @@ describe('validateScoreRanges', () => {
     expect(validateScoreRanges(bad).passed).toBe(false)
   })
 
-  it('should fail when ranks are not sequential', () => {
+  it('should fail when ranks are invalid', () => {
     const ensembles = show2025.classes[0].ensembles.map((e, i) => ({
       ...e,
-      rank: i === 0 ? 5 : e.rank, // break sequential order
+      rank: i === 0 ? 5 : e.rank, // break rank order
     }))
     const bad: ShowData = {
       ...show2025,
       classes: [{ classDef: show2025.classes[0].classDef, ensembles }],
     }
     expect(validateScoreRanges(bad).passed).toBe(false)
+  })
+
+  it('should pass when ranks have ties with correct gaps', () => {
+    // Two-way tie for 1st: [1, 1, 3, 4]
+    const cls = show2025.classes[0]
+    const ensembles = cls.ensembles.slice(0, 4).map((e, i) => ({
+      ...e,
+      rank: i < 2 ? 1 : i + 1,
+    }))
+    const show: ShowData = {
+      ...show2025,
+      classes: [{ classDef: cls.classDef, ensembles }],
+    }
+    expect(validateScoreRanges(show).passed).toBe(true)
+  })
+
+  it('should fail when tie gap is wrong', () => {
+    // Tie for 1st but next rank is 2 instead of 3: [1, 1, 2, 4]
+    const cls = show2025.classes[0]
+    const ensembles = cls.ensembles.slice(0, 4).map((e, i) => ({
+      ...e,
+      rank: i < 2 ? 1 : i,
+    }))
+    const show: ShowData = {
+      ...show2025,
+      classes: [{ classDef: cls.classDef, ensembles }],
+    }
+    expect(validateScoreRanges(show).passed).toBe(false)
   })
 })
 

--- a/src/pipeline/validate.ts
+++ b/src/pipeline/validate.ts
@@ -75,11 +75,29 @@ function validateScoreRanges(showData: ShowData): GateResult {
       }
     }
 
-    // Check ranks are sequential within class
+    // Check ranks follow competition tie rules:
+    // Tied ensembles share the same rank, and the next rank skips ahead
+    // e.g. [1, 1, 3, 4] is valid (two-way tie for 1st, next is 3rd)
     const ranks = cls.ensembles.map((e) => e.rank).sort((a, b) => a - b)
-    for (let i = 0; i < ranks.length; i++) {
-      if (ranks[i] !== i + 1) {
-        errors.push(`${cls.classDef.name}: ranks not sequential — expected ${i + 1}, got ${ranks[i]}`)
+    if (ranks.length > 0 && ranks[0] !== 1) {
+      errors.push(`${cls.classDef.name}: first rank should be 1, got ${ranks[0]}`)
+    }
+    const lastRank = ranks[ranks.length - 1]
+    if (ranks.length > 0 && lastRank !== undefined && lastRank > ranks.length) {
+      errors.push(`${cls.classDef.name}: highest rank ${lastRank} exceeds ensemble count ${ranks.length}`)
+    }
+    for (let i = 1; i < ranks.length; i++) {
+      const prev = ranks[i - 1]
+      const curr = ranks[i]
+      if (prev === undefined || curr === undefined) continue
+      // Each rank must be equal to the previous (tie) or greater
+      if (curr < prev) {
+        errors.push(`${cls.classDef.name}: rank ${curr} appears after ${prev} — out of order`)
+        break
+      }
+      // A non-tied rank must equal its 1-based position (i + 1)
+      if (curr !== prev && curr !== i + 1) {
+        errors.push(`${cls.classDef.name}: rank ${curr} at position ${i + 1} — tie gap mismatch`)
         break
       }
     }


### PR DESCRIPTION
## Summary
- Fixed rank validator rejecting legitimate competition ties (e.g. two ensembles sharing 1st place with rank 2 skipped)
- RMPA Show #4 (March 7, 2026) failed import because Horizon HS and Legend HS tied at 74.600 — this fix unblocks it
- Added tests for valid tie gaps and invalid tie gaps

## Test plan
- [x] Existing rank validation tests pass
- [x] New test: tied ranks with correct gaps `[1, 1, 3, 4]` passes
- [x] New test: tied ranks with wrong gaps `[1, 1, 2, 4]` fails
- [ ] Re-run `score-fallback.yml` after merge to import Show #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)