### PR TITLE
chore: use auto-merged PRs for pipeline data commits

### DIFF
--- a/.github/workflows/schedule-watcher.yml
+++ b/.github/workflows/schedule-watcher.yml
@@ -27,13 +27,21 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.PIPELINE_PAT }}
 
-      - name: Commit and push
+      - name: Open and merge data PR
+        env:
+          GH_TOKEN: ${{ secrets.PIPELINE_PAT }}
         run: |
           git config user.name "score-pipeline[bot]"
           git config user.email "score-pipeline[bot]@users.noreply.github.com"
           git add data/poll-state.json .github/workflows/score-poller.yml
           git diff --cached --quiet && echo "No changes to commit" && exit 0
+          BRANCH="chore/update-poll-state-$(date +%Y%m%d-%H%M%S)"
+          git checkout -b "$BRANCH"
           git commit -m "chore(data): update poll-state and poller schedule
 
           Automated by: score-ingestion-pipeline"
-          git push
+          git push -u origin "$BRANCH"
+          PR_URL=$(gh pr create \
+            --title "chore(data): update poll-state and poller schedule" \
+            --body "Automated by: score-ingestion-pipeline")
+          gh pr merge "$PR_URL" --squash --delete-branch

--- a/.github/workflows/score-fallback.yml
+++ b/.github/workflows/score-fallback.yml
@@ -31,13 +31,21 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Commit and push
+      - name: Open and merge data PR
+        env:
+          GH_TOKEN: ${{ secrets.PIPELINE_PAT }}
         run: |
           git config user.name "score-pipeline[bot]"
           git config user.email "score-pipeline[bot]@users.noreply.github.com"
           git add -A public/data/ data/scores/
           git diff --cached --quiet && echo "No changes to commit" && exit 0
+          BRANCH="chore/fallback-scores-$(date +%Y%m%d-%H%M%S)"
+          git checkout -b "$BRANCH"
           git commit -m "chore(data): fallback score check
 
           Automated by: score-ingestion-pipeline"
-          git push
+          git push -u origin "$BRANCH"
+          PR_URL=$(gh pr create \
+            --title "chore(data): fallback score check" \
+            --body "Automated by: score-ingestion-pipeline")
+          gh pr merge "$PR_URL" --squash --delete-branch

--- a/.github/workflows/score-poller.yml
+++ b/.github/workflows/score-poller.yml
@@ -36,16 +36,24 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Commit and push
+      - name: Open and merge data PR
+        env:
+          GH_TOKEN: ${{ secrets.PIPELINE_PAT }}
         run: |
           git config user.name "score-pipeline[bot]"
           git config user.email "score-pipeline[bot]@users.noreply.github.com"
           git add -A public/data/ data/scores/ data/poll-state.json .github/workflows/score-poller.yml
           git diff --cached --quiet && echo "No changes to commit" && exit 0
+          BRANCH="chore/auto-import-scores-$(date +%Y%m%d-%H%M%S)"
+          git checkout -b "$BRANCH"
           git commit -m "chore(data): auto-import scores
 
           Automated by: score-ingestion-pipeline"
-          git push
+          git push -u origin "$BRANCH"
+          PR_URL=$(gh pr create \
+            --title "chore(data): auto-import scores" \
+            --body "Automated by: score-ingestion-pipeline")
+          gh pr merge "$PR_URL" --squash --delete-branch
 
       - name: Self-disable if no more work
         if: always()

--- a/.github/workflows/season-lifecycle.yml
+++ b/.github/workflows/season-lifecycle.yml
@@ -78,18 +78,26 @@ jobs:
           }" > "$POLL_STATE"
           echo "Reset ${POLL_STATE} for ${YEAR}"
 
-      - name: Commit and push season data
+      - name: Open and merge season data PR
         if: steps.action.outputs.type == 'enable'
+        env:
+          GH_TOKEN: ${{ secrets.PIPELINE_PAT }}
         run: |
           git config user.name "score-pipeline[bot]"
           git config user.email "score-pipeline[bot]@users.noreply.github.com"
           git add public/data/ data/poll-state.json
           git diff --cached --quiet && echo "No data changes to commit" && exit 0
           YEAR=$(date +%Y)
+          BRANCH="chore/init-season-${YEAR}-$(date +%Y%m%d-%H%M%S)"
+          git checkout -b "$BRANCH"
           git commit -m "chore(data): initialize ${YEAR} season
 
           Automated by: season-lifecycle"
-          git push
+          git push -u origin "$BRANCH"
+          PR_URL=$(gh pr create \
+            --title "chore(data): initialize ${YEAR} season" \
+            --body "Automated by: season-lifecycle")
+          gh pr merge "$PR_URL" --squash --delete-branch
 
       - name: Enable season workflows
         if: steps.action.outputs.type == 'enable'

--- a/.github/workflows/sunday-reconciliation.yml
+++ b/.github/workflows/sunday-reconciliation.yml
@@ -31,13 +31,21 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Commit and push
+      - name: Open and merge data PR
+        env:
+          GH_TOKEN: ${{ secrets.PIPELINE_PAT }}
         run: |
           git config user.name "score-pipeline[bot]"
           git config user.email "score-pipeline[bot]@users.noreply.github.com"
           git add -A public/data/ data/scores/
           git diff --cached --quiet && echo "No changes to commit" && exit 0
+          BRANCH="chore/reconcile-scores-$(date +%Y%m%d-%H%M%S)"
+          git checkout -b "$BRANCH"
           git commit -m "chore(data): reconcile weekend scores
 
           Automated by: score-ingestion-pipeline"
-          git push
+          git push -u origin "$BRANCH"
+          PR_URL=$(gh pr create \
+            --title "chore(data): reconcile weekend scores" \
+            --body "Automated by: score-ingestion-pipeline")
+          gh pr merge "$PR_URL" --squash --delete-branch

--- a/src/pipeline/README.md
+++ b/src/pipeline/README.md
@@ -1,6 +1,6 @@
 # Automated Score Pipeline — Operator Guide
 
-Automated pipeline that detects new RMPA scores, downloads and parses them, validates the data, and commits to `main` for automatic deployment via Cloudflare Pages.
+Automated pipeline that detects new RMPA scores, downloads and parses them, validates the data, and merges to `main` via auto-merged PRs for deployment via Cloudflare Pages.
 
 For the full design rationale, see [`docs/designs/AUTO_SCORE_PIPELINE.md`](../../docs/designs/AUTO_SCORE_PIPELINE.md).
 For the implementation plan, see [`docs/plans/pipeline-implementation-plan.md`](../../docs/plans/pipeline-implementation-plan.md).
@@ -15,7 +15,7 @@ On **January 25**, the `season-lifecycle.yml` workflow automatically:
 
 1. Creates `public/data/<YEAR>/season.json` (if it doesn't exist)
 2. Resets `data/poll-state.json` for the new season
-3. Commits the changes to `main`
+3. Opens and squash-merges a PR to `main`
 4. Enables all 4 season workflows (`schedule-watcher`, `score-poller`, `sunday-reconciliation`, `score-fallback`)
 5. Files a summary issue with a verification checklist
 
@@ -38,10 +38,10 @@ You can also trigger this manually: Actions → Season Lifecycle → Run workflo
 
 ### Required Secret: `PIPELINE_PAT`
 
-The lifecycle workflow uses a Personal Access Token to enable/disable other workflows and push workflow file changes (the default `GITHUB_TOKEN` can't do this). The PAT needs the **`actions: write`**, **`contents: write`**, and **`workflows: write`** scopes.
+The pipeline workflows use a Personal Access Token to enable/disable workflows, push workflow file changes, and create/merge PRs (the default `GITHUB_TOKEN` can't do this). The PAT needs the **`actions: write`**, **`contents: write`**, **`pull_requests: write`**, and **`workflows: write`** scopes.
 
 To set it up:
-1. Create a fine-grained PAT at [github.com/settings/tokens](https://github.com/settings/tokens) with `actions: write`, `contents: write`, and `workflows: write` permissions scoped to this repository
+1. Create a fine-grained PAT at [github.com/settings/tokens](https://github.com/settings/tokens) with `actions: write`, `contents: write`, `pull_requests: write`, and `workflows: write` permissions scoped to this repository
 2. Add it as a repository secret named `PIPELINE_PAT` at Settings → Secrets and variables → Actions
 
 ---


### PR DESCRIPTION
## Summary
- All 5 pipeline workflows now create a branch, open a PR, and squash-merge instead of pushing directly to main
- Improves visibility (each data import shows as a PR) and ensures Cloudflare Pages webhooks fire reliably
- Updated PIPELINE_PAT docs to include `pull_requests: write` scope

## Affected workflows
- `score-poller.yml`
- `schedule-watcher.yml`
- `sunday-reconciliation.yml`
- `score-fallback.yml`
- `season-lifecycle.yml`

## Test plan
- [x] After merge, update PIPELINE_PAT to add `pull_requests: write` scope
- [ ] Run `score-fallback.yml` manually and verify a PR is created and auto-merged
- [ ] Verify Cloudflare Pages triggers a rebuild from the merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)